### PR TITLE
Add useful test wrapper functions to FakeExec

### DIFF
--- a/exec/testing/fake_exec.go
+++ b/exec/testing/fake_exec.go
@@ -19,6 +19,11 @@ package testingexec
 import (
 	"fmt"
 	"io"
+	osexec "os/exec"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
 
 	"k8s.io/utils/exec"
 )
@@ -28,13 +33,34 @@ type FakeExec struct {
 	CommandScript []FakeCommandAction
 	CommandCalls  int
 	LookPathFunc  func(string) (string, error)
+
+	T *testing.T
+}
+
+// NewFakeExec creates a FakeExec. You can pass nil for t if you are not running from a
+// test program. (This will cause certain failures to result in a panic rather than a
+// t.Fatal.) cmdsInPath is a list of command names for which LookPath will return a match
+// ("/fake-bin/commandname"); if your code does not use LookPath you can pass nil. (If you
+// need more complex behavior, you can override LookPathFunc on the returned FakeExec.)
+func NewFakeExec(t *testing.T, cmdsInPath []string) *FakeExec {
+	return &FakeExec{
+		T: t,
+		LookPathFunc: func(cmd string) (string, error) {
+			for _, pathCmd := range cmdsInPath {
+				if pathCmd == cmd {
+					return "/fake-bin/" + cmd, nil
+				}
+			}
+			return "", &osexec.Error{Name: cmd, Err: osexec.ErrNotFound}
+		},
+	}
 }
 
 type FakeCommandAction func(cmd string, args ...string) exec.Cmd
 
 func (fake *FakeExec) Command(cmd string, args ...string) exec.Cmd {
 	if fake.CommandCalls > len(fake.CommandScript)-1 {
-		panic(fmt.Sprintf("ran out of Command() actions. Could not handle command [%d]: %s args: %v", fake.CommandCalls, cmd, args))
+		fake.fail("ran out of Command() actions at %s executing %v", getCaller(1), append([]string{cmd}, args...))
 	}
 	i := fake.CommandCalls
 	fake.CommandCalls++
@@ -43,6 +69,82 @@ func (fake *FakeExec) Command(cmd string, args ...string) exec.Cmd {
 
 func (fake *FakeExec) LookPath(file string) (string, error) {
 	return fake.LookPathFunc(file)
+}
+
+func getCaller(n int) string {
+	_, file, line, ok := runtime.Caller(n + 1)
+	if !ok {
+		return "???"
+	}
+	if i := strings.LastIndexAny(file, "/\\"); i >= 0 {
+		file = file[i+1:]
+	}
+	return fmt.Sprintf("%s:%d", file, line)
+}
+
+func (fake *FakeExec) fail(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if fake.T == nil {
+		panic(msg)
+	}
+
+	// Don't re-fail from a "defer fexec.AssertExpectedCommands()" if we already failed once
+	if fake.T.Failed() {
+		return
+	}
+	fake.T.Fatal(msg)
+}
+
+// AddCommand adds a Cmd to be returned by a future fake.Command(...) call. Call
+// SetCombinedOutput or SetRunOutput on the result to specify its result.
+func (fake *FakeExec) AddCommand(cmd string, args ...string) *FakeCmd {
+	expectCaller := getCaller(1)
+	expectedArgv := append([]string{cmd}, args...)
+	fcmd := &FakeCmd{}
+	fake.CommandScript = append(fake.CommandScript,
+		func(cmd string, args ...string) exec.Cmd {
+			InitFakeCmd(fcmd, cmd, args...)
+			if !reflect.DeepEqual(expectedArgv, fcmd.Argv) {
+				fake.fail("Wrong command: expected\n%v (at %s)\ngot\n%v (at %s)", expectedArgv, expectCaller, fcmd.Argv, getCaller(2))
+			}
+			return fcmd
+		},
+	)
+	return fcmd
+}
+
+func outputAsBytes(output interface{}) []byte {
+	if outputBytes, ok := output.([]byte); ok {
+		return outputBytes
+	} else if outputStr, ok := output.(string); ok {
+		return []byte(outputStr)
+	} else if output == nil {
+		return nil
+	}
+	panic("output must be []byte or string")
+}
+
+// SetRunOutput provides the result of calling Run() on a FakeCmd.
+// stdout and stderr can be either []byte or string (which will be converted to []byte).
+func (fcmd *FakeCmd) SetRunOutput(stdout, stderr interface{}, err error) {
+	fcmd.RunScript = []FakeRunAction{
+		func() ([]byte, []byte, error) { return outputAsBytes(stdout), outputAsBytes(stderr), err },
+	}
+}
+
+// SetCombinedOutput provides the result of calling CombinedOutput() on a FakeCmd.
+// output can be either a []byte or a string (which will be converted to a []byte).
+func (fcmd *FakeCmd) SetCombinedOutput(output interface{}, err error) {
+	fcmd.CombinedOutputScript = []FakeCombinedOutputAction{
+		func() ([]byte, error) { return outputAsBytes(output), err },
+	}
+}
+
+// AssertExpectedCommands ensures that all of the commands added to fake via AddCommand were actually executed
+func (fake *FakeExec) AssertExpectedCommands() {
+	if fake.CommandCalls != len(fake.CommandScript) {
+		fake.fail("Only used %d of %d expected commands (at %s)", fake.CommandCalls, len(fake.CommandScript), getCaller(1))
+	}
 }
 
 // A simple scripted Cmd type.


### PR DESCRIPTION
Migrated from https://github.com/kubernetes/kubernetes/pull/46537...

----

The fake implementation of pkg/util/exec for test programs is kind of really annoying to use. This PR adds some wrapper functions to make it easier, AND to automatically check that the passed-in command was what you expected (which some tests were doing but most weren't).

So:

    fcmd := fakeexec.FakeCmd{
            CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
                    // iptables version check
                    func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
                    // iptables-restore version check
                    func() ([]byte, error) { return []byte("iptables-restore v1.9.22"), nil },
                    // Success.
                    func() ([]byte, error) { return []byte{}, nil },
            },
    }
    fexec := fakeexec.FakeExec{
            CommandScript: []fakeexec.FakeCommandAction{
                    func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
                    func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
                    func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
            },
    }

becomes

    fexec := fakeexec.NewFakeExec(t, nil)
    fexec.AddCommand("iptables", "--version").
    	SetCombinedOutput("iptables v1.9.22", nil)
    fexec.AddCommand("iptables-restore", "--version").
    	SetCombinedOutput("iptables-restore v1.9.22", nil)
    fexec.AddCommand("iptables", "-w2", "-N", "FOOBAR", "-t", "nat").
    	SetCombinedOutput("", nil)

There's some discussion on the original kubernetes bug (which I'm going to rebase on top of this to cover only the "porting pkg/util to the new interface" part). The June 27 comment about it not passing "make verify" no longer seems to be a problem with the migration of fakeexec into a separate subdirectory.