### PR TITLE
Test against go 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go:
   - 1.6.x
   - 1.7.x
   - 1.8.x
+  - 1.9.x
 go_import_path: k8s.io/utils
 script:
   - diff -u <(echo -n) <(gofmt -d .)


### PR DESCRIPTION
Kubernetes now compiles with go 1.9, so we should definitely test
against that version.