### PR TITLE
exec supports context (timeout/cancel)

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package exec
 
 import (
+	"context"
 	"io"
 	osexec "os/exec"
 	"syscall"
@@ -32,6 +33,13 @@ type Interface interface {
 	// Command returns a Cmd instance which can be used to run a single command.
 	// This follows the pattern of package os/exec.
 	Command(cmd string, args ...string) Cmd
+
+	// CommandContext returns a Cmd instance which can be used to run a single command.
+	//
+	// The provided context is used to kill the process if the context becomes done
+	// before the command completes on its own. For example, a timeout can be set in
+	// the context.
+	CommandContext(ctx context.Context, cmd string, args ...string) Cmd
 
 	// LookPath wraps os/exec.LookPath
 	LookPath(file string) (string, error)
@@ -79,7 +87,7 @@ func New() Interface {
 
 // Command is part of the Interface interface.
 func (executor *executor) Command(cmd string, args ...string) Cmd {
-	return (*cmdWrapper)(osexec.Command(cmd, args...))
+	return &cmdWrapper{osexec.Command(cmd, args...)}
 }
 
 // LookPath is part of the Interface interface
@@ -87,8 +95,15 @@ func (executor *executor) LookPath(file string) (string, error) {
 	return osexec.LookPath(file)
 }
 
+// CommandContext is part of the Interface interface.
+func (executor *executor) CommandContext(ctx context.Context, cmd string, args ...string) Cmd {
+	return &cmdWrapper{osexec.CommandContext(ctx, cmd, args...)}
+}
+
 // Wraps exec.Cmd so we can capture errors.
-type cmdWrapper osexec.Cmd
+type cmdWrapper struct {
+	*osexec.Cmd
+}
 
 var _ Cmd = &cmdWrapper{}
 
@@ -110,52 +125,51 @@ func (cmd *cmdWrapper) SetStderr(out io.Writer) {
 
 // Run is part of the Cmd interface.
 func (cmd *cmdWrapper) Run() error {
-	return (*osexec.Cmd)(cmd).Run()
+	err := cmd.Cmd.Run()
+	return handleError(err)
 }
 
 // CombinedOutput is part of the Cmd interface.
 func (cmd *cmdWrapper) CombinedOutput() ([]byte, error) {
-	out, err := (*osexec.Cmd)(cmd).CombinedOutput()
-	if err != nil {
-		return out, handleError(err)
-	}
-	return out, nil
+	out, err := cmd.Cmd.CombinedOutput()
+	return out, handleError(err)
 }
 
 func (cmd *cmdWrapper) Output() ([]byte, error) {
-	out, err := (*osexec.Cmd)(cmd).Output()
-	if err != nil {
-		return out, handleError(err)
-	}
-	return out, nil
+	out, err := cmd.Cmd.Output()
+	return out, handleError(err)
 }
 
 // Stop is part of the Cmd interface.
 func (cmd *cmdWrapper) Stop() {
-	c := (*osexec.Cmd)(cmd)
-	if c.ProcessState.Exited() {
+	c := cmd.Cmd
+	if c.Process == nil {
 		return
 	}
+
 	c.Process.Signal(syscall.SIGTERM)
+
 	time.AfterFunc(10*time.Second, func() {
-		if c.ProcessState.Exited() {
-			return
+		if c.ProcessState != nil && !c.ProcessState.Exited() {
+			c.Process.Signal(syscall.SIGKILL)
 		}
-		c.Process.Signal(syscall.SIGKILL)
 	})
 }
 
 func handleError(err error) error {
-	if ee, ok := err.(*osexec.ExitError); ok {
-		// Force a compile fail if exitErrorWrapper can't convert to ExitError.
-		var x ExitError = &ExitErrorWrapper{ee}
-		return x
+	if err == nil {
+		return nil
 	}
-	if ee, ok := err.(*osexec.Error); ok {
-		if ee.Err == osexec.ErrNotFound {
+
+	switch e := err.(type) {
+	case *osexec.ExitError:
+		return &ExitErrorWrapper{e}
+	case *osexec.Error:
+		if e.Err == osexec.ErrNotFound {
 			return ErrExecutableNotFound
 		}
 	}
+
 	return err
 }
 
@@ -165,10 +179,10 @@ type ExitErrorWrapper struct {
 	*osexec.ExitError
 }
 
-var _ ExitError = ExitErrorWrapper{}
+var _ ExitError = &ExitErrorWrapper{}
 
 // ExitStatus is part of the ExitError interface.
-func (eew ExitErrorWrapper) ExitStatus() int {
+func (eew *ExitErrorWrapper) ExitStatus() int {
 	ws, ok := eew.Sys().(syscall.WaitStatus)
 	if !ok {
 		panic("can't call ExitStatus() on a non-WaitStatus exitErrorWrapper")

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package exec
 
 import (
+	"context"
 	osexec "os/exec"
 	"testing"
+	"time"
 )
 
 func TestExecutorNoArgs(t *testing.T) {
@@ -100,4 +102,20 @@ func TestExecutableNotFound(t *testing.T) {
 	if err != ErrExecutableNotFound {
 		t.Errorf("Expected error ErrExecutableNotFound but got %v", err)
 	}
+}
+
+func TestTimeout(t *testing.T) {
+	exec := New()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+
+	err := exec.CommandContext(ctx, "sleep", "2").Run()
+	if err == nil {
+		t.Errorf("expected error but got %v", err)
+	}
+}
+
+func TestStopBeforeStart(t *testing.T) {
+	// It shouldn't panic!
+	New().Command("sleep", "1").Stop()
 }


### PR DESCRIPTION
- Add function CommandContext as os/exec does
- Clean up the code a little bit to make it more readable
- Fix panic when calling Stop before Start

Fixes: https://github.com/kubernetes/kubernetes/issues/5644