### PR TITLE
Implement CommandContext in exec util

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
 go:
-  - 1.6.x
-  - 1.7.x
   - 1.8.x
   - 1.9.x
 go_import_path: k8s.io/utils

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package exec
 
 import (
+	"context"
 	"io"
 	osexec "os/exec"
 	"syscall"
@@ -32,6 +33,13 @@ type Interface interface {
 	// Command returns a Cmd instance which can be used to run a single command.
 	// This follows the pattern of package os/exec.
 	Command(cmd string, args ...string) Cmd
+
+	// CommandContext returns a Cmd instance which can be used to run a single command.
+	//
+	// The provided context is used to kill the process if the context becomes done
+	// before the command completes on its own. For example, a timeout can be set in
+	// the context.
+	CommandContext(ctx context.Context, cmd string, args ...string) Cmd
 
 	// LookPath wraps os/exec.LookPath
 	LookPath(file string) (string, error)
@@ -80,6 +88,11 @@ func New() Interface {
 // Command is part of the Interface interface.
 func (executor *executor) Command(cmd string, args ...string) Cmd {
 	return (*cmdWrapper)(osexec.Command(cmd, args...))
+}
+
+// CommandContext is part of the Interface interface.
+func (executor *executor) CommandContext(ctx context.Context, cmd string, args ...string) Cmd {
+	return (*cmdWrapper)(osexec.CommandContext(ctx, cmd, args...))
 }
 
 // LookPath is part of the Interface interface

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package exec
 
 import (
+	"context"
 	osexec "os/exec"
 	"testing"
+	"time"
 )
 
 func TestExecutorNoArgs(t *testing.T) {
@@ -112,4 +114,15 @@ func TestStopBeforeStart(t *testing.T) {
 
 	// no panic calling Stop after command is done
 	cmd.Stop()
+}
+
+func TestTimeout(t *testing.T) {
+	exec := New()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+
+	err := exec.CommandContext(ctx, "sleep", "2").Run()
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected %v but got %v", context.DeadlineExceeded, err)
+	}
 }


### PR DESCRIPTION
With CommandContext, it supports add timeout to a command execution or
cancel it.

Fixes: kubernetes/kubernetes#5644