### PR TITLE
WIP: unstructured: Walk Json/Yaml interface types

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ an existing package to this repository.
 - [Temp](/temp) provides an interface to create temporary directories. It also
   provides a [FakeDir](temp/temptesting) implementation to replace in tests.
 
+- [Unstructured](/unstructured) provide utility structures utility functions to
+  walk through, and modify unstructured json/yaml `interface{}` objects.
 
 [Build Status]: https://travis-ci.org/kubernetes/utils.svg?branch=master
 [Go standard libs]: https://golang.org/pkg/#stdlib

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ an existing package to this repository.
 
 ## Libraries
 
+- [Clock](/clock) provides an interface for time-based operations.  It allows
+  mocking time for testing.
+
 - [Exec](/exec) provides an interface for `os/exec`. It makes it easier
   to mock and replace in tests, especially with
   the [FakeExec](exec/testing/fake_exec.go) struct.
@@ -43,8 +46,6 @@ an existing package to this repository.
 - [Temp](/temp) provides an interface to create temporary directories. It also
   provides a [FakeDir](temp/temptesting) implementation to replace in tests.
 
-- [Clock](/clock) provides an interface for time-based operations.  It allows
-  mocking time for testing.
 
 [Build Status]: https://travis-ci.org/kubernetes/utils.svg?branch=master
 [Go standard libs]: https://golang.org/pkg/#stdlib

--- a/unstructured/broken.go
+++ b/unstructured/broken.go
@@ -1,0 +1,30 @@
+package unstructured
+
+// broken is a Chainable that is used when the chain is broken, but
+// since we can't return the error, we just go wherever needed while
+// carrying that err.
+type broken struct {
+	Error error
+}
+
+var _ Chainable = broken{}
+
+func (c broken) Data() (interface{}, error) {
+	return nil, c.Error
+}
+
+func (c broken) Field(key string) Chainable {
+	return c
+}
+
+func (c broken) SetField(key string, value interface{}) Chainable {
+	return c
+}
+
+func (c broken) At(index int) Chainable {
+	return c
+}
+
+func (c broken) SetAt(index int, value interface{}) Chainable {
+	return c
+}

--- a/unstructured/broken_test.go
+++ b/unstructured/broken_test.go
@@ -1,0 +1,17 @@
+package unstructured
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestBroken(t *testing.T) {
+	_, err := broken{Error: errors.New("broken...")}.
+		Field("SomeField").
+		SetField("SomeOtherField", 1).
+		At(1).
+		SetAt(0, 12).Data()
+	if err.Error() != "broken..." {
+		t.Fatalf(`Expected error to be "broken...", got: %v`, err)
+	}
+}

--- a/unstructured/chainable.go
+++ b/unstructured/chainable.go
@@ -1,0 +1,34 @@
+package unstructured
+
+// Chainable is an interface to a more-easily chain Unstructured types.
+type Chainable interface {
+	// Data returns the data pointed by the current element, or the
+	// current saved error. The error might have been carried from a
+	// previous failure to reach or change an element.
+	//
+	// Note that the first error will preempt over all other
+	// operations. In other words, if you chain multiple set
+	// operations, only the ones before the first failure will happen,
+	// others will be ignored.
+	Data() (interface{}, error)
+
+	// Field returns a Chainable to the value of the "key" field.
+	// If the current object is not a map, this will return a
+	// Chainable containing an error.
+	Field(key string) Chainable
+	// SetField changes the value of the "key" field in the map.
+	// This operation doesn't change the Chainable, so that you can
+	// set multiple fields consecutively. If the current object is
+	// not a map, this will return a Chainable containing an error.
+	SetField(key string, value interface{}) Chainable
+	// At returns a Chainable to the value at the index-th item. If
+	// the current object is not an array, this will return a
+	// Chainable containing an error.
+	At(index int) Chainable
+	// SetAt changes the value of the index-th item in the array.
+	// This operation doesn't change the Chainable, so that you can
+	// set multiple field consecutively. If the current object is
+	// not an array, this will return a Chainable container an
+	// error.
+	SetAt(index int, value interface{}) Chainable
+}

--- a/unstructured/chainer.go
+++ b/unstructured/chainer.go
@@ -1,0 +1,64 @@
+package unstructured
+
+import "fmt"
+
+type chainer struct {
+	data interface{}
+
+	// path is used to build the path as we walk through the
+	// chain. This is used to build the error when we have one.
+	path string
+}
+
+// NewChainable returns a Chainable for the given object.
+func NewChainable(value interface{}) Chainable {
+	return chainer{data: value}
+}
+
+func (c chainer) Data() (interface{}, error) {
+	return c.data, nil
+}
+
+func (c chainer) Field(key string) Chainable {
+	f, err := Unstructured{c.data}.Field(key)
+	if err != nil {
+		return broken{
+			Error: fmt.Errorf("error getting key %q in %s: %v",
+				key, c.path, err),
+		}
+	}
+	return chainer{data: f.Data, path: c.path + fmt.Sprintf(".%s", key)}
+}
+
+func (c chainer) SetField(key string, value interface{}) Chainable {
+	err := Unstructured{c.data}.SetField(key, value)
+	if err != nil {
+		return broken{
+			Error: fmt.Errorf("error setting key %q in %s: %v",
+				key, c.path, err),
+		}
+	}
+	return c
+}
+
+func (c chainer) At(index int) Chainable {
+	f, err := Unstructured{c.data}.At(index)
+	if err != nil {
+		return broken{
+			Error: fmt.Errorf(`error getting item "%d" in %q: %v`,
+				index, c.path, err),
+		}
+	}
+	return chainer{data: f.Data, path: c.path + fmt.Sprintf("[%d]", index)}
+}
+
+func (c chainer) SetAt(index int, value interface{}) Chainable {
+	err := Unstructured{c.data}.SetAt(index, value)
+	if err != nil {
+		return broken{
+			Error: fmt.Errorf(`error setting item "%d" in %q: %v`,
+				index, c.path, err),
+		}
+	}
+	return c
+}

--- a/unstructured/doc.go
+++ b/unstructured/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package unstructured provides utility functions to walk through, and
+// modify an unstructured json or yaml object (decoded into an
+// interface{})
+package unstructured

--- a/unstructured/example_chainable_test.go
+++ b/unstructured/example_chainable_test.go
@@ -1,0 +1,58 @@
+package unstructured
+
+import (
+	"fmt"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+func ExampleNewChainable() {
+	data := map[interface{}]interface{}{
+		"int":    1,
+		"string": "my string",
+		"list": []interface{}{
+			"number1",
+			map[interface{}]interface{}{
+				"deep": "deep",
+				"very": "deep",
+			},
+			3,
+		},
+	}
+	NewChainable(data).
+		SetField("int", 5).
+		SetField("string", "new string").
+		Field("list").
+		SetAt(0, "number 0").
+		At(1).SetField("deeper", "string")
+
+	y, _ := yaml.Marshal(data)
+	fmt.Println(string(y))
+	// Output: int: 5
+	// list:
+	// - number 0
+	// - deep: deep
+	//   deeper: string
+	//   very: deep
+	// - 3
+	// string: new string
+}
+
+func ExampleNewChainable_broken() {
+	data := map[interface{}]interface{}{
+		"list": []interface{}{
+			map[interface{}]interface{}{
+				"int": 5,
+			},
+		},
+	}
+	_, err := NewChainable(data).
+		Field("list").
+		At(0).
+		Field("int").
+		SetField("foo", "bar"). // This is an int, not a map. value is not set.
+		SetAt(0, "some-value"). // We had an erorr already, value is not set.
+		Data()
+	fmt.Println(err)
+	// Output: error setting key "foo" in .list[0].int: invalid type
+}

--- a/unstructured/example_unstructured_test.go
+++ b/unstructured/example_unstructured_test.go
@@ -1,0 +1,67 @@
+package unstructured
+
+import (
+	"fmt"
+)
+
+func ExampleUnstructured_Field() {
+	data := map[interface{}]interface{}{
+		"int":    1,
+		"string": "my string",
+	}
+
+	fmt.Println(Unstructured{Data: data}.Field("string"))
+	// Output: {my string} <nil>
+}
+
+func ExampleUnstructured_Field_missingkey() {
+	data := map[interface{}]interface{}{
+		"int":    1,
+		"string": "my string",
+	}
+
+	fmt.Println(Unstructured{Data: data}.Field("randomkey"))
+	// Output: {<nil>} field not found
+}
+
+func ExampleUnstructured_Field_invalidtype() {
+	data := []interface{}{
+		"string",
+		5,
+	}
+
+	fmt.Println(Unstructured{Data: data}.Field("randomkey"))
+	// Output: {<nil>} invalid type
+}
+
+func ExampleUnstructured_SetField() {
+	data := map[interface{}]interface{}{
+		"int":    1,
+		"string": "my string",
+	}
+
+	Unstructured{Data: data}.SetField("string", "my new string")
+	fmt.Println(Unstructured{Data: data}.Field("string"))
+	// Output: {my new string} <nil>
+}
+
+func ExampleUnstructured_At() {
+	data := []interface{}{
+		"string",
+		5,
+	}
+
+	fmt.Println(Unstructured{Data: data}.At(1))
+	// Output: {5} <nil>
+}
+
+func ExampleUnstructured_SetAt() {
+	data := []interface{}{
+		"string",
+		5,
+	}
+
+	Unstructured{Data: data}.SetAt(1, 4.2)
+	fmt.Println(Unstructured{Data: data}.At(1))
+	// Output: {4.2} <nil>
+}

--- a/unstructured/unstructured.go
+++ b/unstructured/unstructured.go
@@ -1,0 +1,94 @@
+package unstructured
+
+import (
+	"errors"
+)
+
+var missingField = errors.New("field not found")
+var invalidIndex = errors.New("index is out of bound")
+var invalidType = errors.New("invalid type")
+
+// Unstructured is the object that let's you manipulate Data.
+type Unstructured struct {
+	Data interface{}
+}
+
+// Field returns the Unstructured object in the "key" field, if this
+// object is a map.
+//
+// If the object is not a map, or if the field doesn't exist, an error
+// is returned.
+func (u Unstructured) Field(key string) (Unstructured, error) {
+	m, ok := u.Data.(map[interface{}]interface{})
+	if !ok {
+		return Unstructured{}, invalidType
+	}
+	d, ok := m[key]
+	if !ok {
+		return Unstructured{}, missingField
+	}
+	return Unstructured{Data: d}, nil
+}
+
+// SetField sets the value in the "key" field of the Unstructured
+// object, if this object is a map.
+//
+// If the object is not a map, an error is returned.
+func (u Unstructured) SetField(key string, value interface{}) error {
+	m, ok := u.Data.(map[interface{}]interface{})
+	if !ok {
+		return invalidType
+	}
+	m[key] = value
+	return nil
+}
+
+// At returns the "index"-th item in the list, if this object is an
+// array.
+//
+// If the object is not an array, or if the index is out-of-bound, an
+// error is returned.
+func (u Unstructured) At(index int) (Unstructured, error) {
+	a, ok := u.Data.([]interface{})
+	if !ok {
+		return Unstructured{}, invalidType
+	}
+	if index < 0 || index >= len(a) {
+		return Unstructured{}, invalidIndex
+	}
+	return Unstructured{Data: a[index]}, nil
+}
+
+// SetAt sets the value for the index-th field of the Unstructured
+// object, if this object is an array.
+//
+// If the object is not a map, an error is returned.
+func (u Unstructured) SetAt(index int, value interface{}) error {
+	a, ok := u.Data.([]interface{})
+	if !ok {
+		return invalidType
+	}
+	if index < 0 || index >= len(a) {
+		return invalidIndex
+	}
+	a[index] = value
+	return nil
+}
+
+// InsertAt inserts the value at the index-th position in the
+// Unstructured object, if this object is an array. The new array is
+// returned, and needs to be re-inserted where needed.
+//
+// If the object is not an array, or if the index is out-of-bound, an
+// error is returned.
+func (u *Unstructured) InsertAt(index int, value interface{}) ([]interface{}, error) {
+	a, ok := u.Data.([]interface{})
+	if !ok {
+		return nil, invalidType
+	}
+
+	a = append(a, 0)
+	copy(a[index+1:], a[index:])
+	a[index] = value
+	return a, nil
+}

--- a/unstructured/unstructured_test.go
+++ b/unstructured/unstructured_test.go
@@ -1,0 +1,102 @@
+package unstructured
+
+import "testing"
+
+func TestField(t *testing.T) {
+	u, err := Unstructured{Data: map[interface{}]interface{}{"field": 5}}.Field("field")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Data.(int) != 5 {
+		t.Errorf(`Expected "u" to be 5, got %d`, u.Data.(int))
+	}
+}
+
+func TestFieldMissing(t *testing.T) {
+	_, err := Unstructured{Data: map[interface{}]interface{}{"field": 5}}.Field("not-there")
+	if err != missingField {
+		t.Fatalf(`Expected error to be %q, got: %q`, missingField, err)
+	}
+}
+
+func TestFieldInvalidType(t *testing.T) {
+	_, err := Unstructured{Data: []interface{}{"field"}}.Field("field")
+	if err != invalidType {
+		t.Fatalf(`Expected error to be %q, got: %q`, missingField, err)
+	}
+}
+
+func TestSetField(t *testing.T) {
+	u := Unstructured{Data: map[interface{}]interface{}{"field": 5}}
+	err := u.SetField("field", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := u.Field("field")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Data.(int) != 1 {
+		t.Errorf(`Expected "u" to be 5, got %d`, d.Data.(int))
+	}
+}
+
+func TestSetFieldInvalid(t *testing.T) {
+	u := Unstructured{Data: []interface{}{"field"}}
+	err := u.SetField("field", 1)
+	if err != invalidType {
+		t.Fatalf(`Expected error to be %q, got: %q`, missingField, err)
+	}
+}
+
+func TestAt(t *testing.T) {
+	u, err := Unstructured{Data: []interface{}{"field", 5}}.At(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Data.(int) != 5 {
+		t.Errorf(`Expected "u" to be 5, got %d`, u.Data.(int))
+	}
+}
+
+func TestAtOutOfBOund(t *testing.T) {
+	_, err := Unstructured{Data: []interface{}{"field", 5}}.At(-1)
+	if err != invalidIndex {
+		t.Fatalf(`Expected error to be %q, got: %q`, invalidIndex, err)
+	}
+
+	_, err = Unstructured{Data: []interface{}{"field", 5}}.At(5)
+	if err != invalidIndex {
+		t.Fatalf(`Expected error to be %q, got: %q`, invalidIndex, err)
+	}
+}
+
+func TestAtInvalidType(t *testing.T) {
+	_, err := Unstructured{Data: map[interface{}]interface{}{"field": 5}}.At(0)
+	if err != invalidType {
+		t.Fatalf(`Expected error to be %q, got: %q`, invalidType, err)
+	}
+}
+
+func TestSetAt(t *testing.T) {
+	u := Unstructured{Data: []interface{}{"field", 5}}
+	err := u.SetAt(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := u.At(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Data.(int) != 1 {
+		t.Errorf(`Expected "u" to be 5, got %d`, d.Data.(int))
+	}
+}
+
+func TestSetAtInvalid(t *testing.T) {
+	u := Unstructured{Data: map[interface{}]interface{}{"field": 5}}
+	err := u.SetAt(0, 1)
+	if err != invalidType {
+		t.Fatalf(`Expected error to be %q, got: %q`, invalidIndex, err)
+	}
+}


### PR DESCRIPTION
This creates a new package that helps you navigate through an
unstructured interface{} decoded from Json or Yaml. You can either use
the `Unstructured` typed, but you have to check for errors at each level,
or a `Chainable`, which will record the error if you have one and give
it to you at the end of the chain.