### PR TITLE
Fix cancelling timers in FakeClock package

### DIFF
--- a/clock/testing/fake_clock_test.go
+++ b/clock/testing/fake_clock_test.go
@@ -182,3 +182,15 @@ func TestFakeTick(t *testing.T) {
 		t.Errorf("unexpected number of accumulated ticks: %d", accumulatedTicks)
 	}
 }
+
+func TestFakeStop(t *testing.T) {
+	tc := NewFakeClock(time.Now())
+	timer := tc.NewTimer(time.Second)
+	if !tc.HasWaiters() {
+		t.Errorf("expected a waiter to be present, but it is not")
+	}
+	timer.Stop()
+	if tc.HasWaiters() {
+		t.Errorf("expected existing waiter to be cleaned up, but it is still present")
+	}
+}


### PR DESCRIPTION
This existing timer implementation used for testing does not properly support cancellation.

This is because of how pointers and copies are handled in the FakeClock structure.

Here, we determine whether to still retain a timer by comparing the registered waiters and the current timer/waiter, and if they do not match, we retain the timer (as it is not the timer being cancelled): https://github.com/kubernetes/utils/blob/master/clock/testing/fake_clock.go#L225-L240

However, we instantiate the `fakeClockWaiter` as a non-pointer within the Timer structure, and record this structure in a slice stored on the FakeClock. You can see that happening here: https://github.com/kubernetes/utils/blob/master/clock/testing/fake_clock.go#L89-L94

The issue is that on L94, we actually create a copy of the `fakeClockWaiter`, which means that the comparison on L232 will never match, and so *all* timers will be retained.

This PR changes the slice in the FakeClock to be a slice of *pointers*, which resolves the issue.
Unit tests still pass with this new adapted version, and my own tests that rely on this package are now passing too.