### PR TITLE
add stewart-yu to OWNER files

### DIFF
--- a/pointer/OWNERS
+++ b/pointer/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+- apelisse
+- stewart-yu
+- thockin
+reviewers:
+- apelisse
+- stewart-yu
+- thockin


### PR DESCRIPTION
Forgot comment to [PR](https://github.com/kubernetes/utils/pull/45), I'd like add myself to OWNER file because `/pointer` directory own to me : https://github.com/kubernetes/utils/tree/master/pointer
Thanks