### PR TITLE
Support os/exec.Cmd.Env

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -60,6 +60,7 @@ type Cmd interface {
 	SetStdin(in io.Reader)
 	SetStdout(out io.Writer)
 	SetStderr(out io.Writer)
+	SetEnv(env []string)
 	// Stops the command by sending SIGTERM. It is not guaranteed the
 	// process will stop before this function returns. If the process is not
 	// responding, an internal timer function will send a SIGKILL to force
@@ -119,6 +120,10 @@ func (cmd *cmdWrapper) SetStdout(out io.Writer) {
 
 func (cmd *cmdWrapper) SetStderr(out io.Writer) {
 	cmd.Stderr = out
+}
+
+func (cmd *cmdWrapper) SetEnv(env []string) {
+	cmd.Env = env
 }
 
 // Run is part of the Cmd interface.

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -139,3 +139,25 @@ func TestTimeout(t *testing.T) {
 		t.Errorf("expected %v but got %v", context.DeadlineExceeded, err)
 	}
 }
+
+func TestSetEnv(t *testing.T) {
+	ex := New()
+
+	out, err := ex.Command("/bin/sh", "-c", "echo $FOOBAR").CombinedOutput()
+	if err != nil {
+		t.Errorf("expected success, got %+v", err)
+	}
+	if string(out) != "\n" {
+		t.Errorf("unexpected output: %q", string(out))
+	}
+
+	cmd := ex.Command("/bin/sh", "-c", "echo $FOOBAR")
+	cmd.SetEnv([]string{"FOOBAR=baz"})
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Errorf("expected success, got %+v", err)
+	}
+	if string(out) != "baz\n" {
+		t.Errorf("unexpected output: %q", string(out))
+	}
+}

--- a/exec/testing/fake_exec.go
+++ b/exec/testing/fake_exec.go
@@ -65,6 +65,7 @@ type FakeCmd struct {
 	Stdin                io.Reader
 	Stdout               io.Writer
 	Stderr               io.Writer
+	Env                  []string
 }
 
 var _ exec.Cmd = &FakeCmd{}
@@ -91,6 +92,10 @@ func (fake *FakeCmd) SetStdout(out io.Writer) {
 
 func (fake *FakeCmd) SetStderr(out io.Writer) {
 	fake.Stderr = out
+}
+
+func (fake *FakeCmd) SetEnv(env []string) {
+	fake.Env = env
 }
 
 func (fake *FakeCmd) Run() error {


### PR DESCRIPTION
`exec.Cmd` is missing `os/exec.Cmd.Env`