### PR TITLE
Install realpath during testing in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+dist: xenial
 go:
   - 1.8.x
   - 1.9.x
@@ -7,7 +8,3 @@ script:
   - diff -u <(echo -n) <(gofmt -d .)
   - go tool vet .
   - go test -v -race ./...
-addons:
-  apt:
-    packages:
-      - coreutils


### PR DESCRIPTION
The nsenter tests require an implementation of realpath but Ubuntu stripped it from coreutils in 8.20-2 because they were already shipping it in a different package. From Xenial onward Ubuntu started shipping realpath with the coreutils package instead of in a different package but Xenial is not yet supported on Travis.

Fixes issues in #52 

/kind bugfix
/assign @thockin 