### PR TITLE
Add Makefile and build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,4 @@ go:
   - 1.11.x
 go_import_path: k8s.io/utils
 script:
-  - go get -t -v ./...
-  - diff -u <(echo -n) <(gofmt -d .)
-  - diff -u <(echo -n) <(golint $(go list -e ./...))
-  - go tool vet .
-  - go test -v -race ./...
-install:
-  - go get golang.org/x/lint/golint
+  - make verify

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: verify
+verify: depend verify-fmt verify-lint vet
+	go test -v -race ./...
+
+.PHONY: depend
+depend:
+	go get -t -v ./...
+
+.PHONY: verify-fmt
+verify-fmt:
+	./hack/verify-gofmt.sh
+
+.PHONY: verify-lint
+verify-lint:
+	./hack/verify-golint.sh
+
+.PHONY: vet
+vet:
+	go tool vet .
+
+.PHONY: update-fmt
+update-fmt:
+	gofmt -s -w .

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if ! which gofmt > /dev/null; then
+  echo "Can not find gofmt"
+  exit 1
+fi
+
+diff=$(gofmt -s -d . 2>&1)
+if [[ -n "${diff}" ]]; then
+  echo "${diff}"
+  echo
+  echo "Please run 'make update-fmt'"
+  exit 1
+fi

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if ! which golint > /dev/null; then
+    echo "installing golint"
+    go get golang.org/x/lint/golint
+fi
+
+errors="$(golint ./...)"
+if [[ -n "$errors" ]]; then
+  echo "Errors from golint:"
+  echo
+  echo "${errors}"
+  exit 1
+fi


### PR DESCRIPTION
Adds a `Makefile` and a few hack scripts that do the same things the `.travis.yml` is currently doing. The purpose of this change is to make it easier to test modifications to this package before submitting them.

/kind feature
/assign @thockin