### PR TITLE
[exec] Implement Start, Wait & StdIOPipe methods

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -61,6 +61,16 @@ type Cmd interface {
 	SetStdout(out io.Writer)
 	SetStderr(out io.Writer)
 	SetEnv(env []string)
+
+	// StdoutPipe and StderrPipe for getting the process' Stdout and Stderr as
+	// Readers
+	StdoutPipe() (io.ReadCloser, error)
+	StderrPipe() (io.ReadCloser, error)
+
+	// Start and Wait are for running a process non-blocking
+	Start() error
+	Wait() error
+
 	// Stops the command by sending SIGTERM. It is not guaranteed the
 	// process will stop before this function returns. If the process is not
 	// responding, an internal timer function will send a SIGKILL to force
@@ -124,6 +134,26 @@ func (cmd *cmdWrapper) SetStderr(out io.Writer) {
 
 func (cmd *cmdWrapper) SetEnv(env []string) {
 	cmd.Env = env
+}
+
+func (cmd *cmdWrapper) StdoutPipe() (io.ReadCloser, error) {
+	r, err := (*osexec.Cmd)(cmd).StdoutPipe()
+	return r, handleError(err)
+}
+
+func (cmd *cmdWrapper) StderrPipe() (io.ReadCloser, error) {
+	r, err := (*osexec.Cmd)(cmd).StderrPipe()
+	return r, handleError(err)
+}
+
+func (cmd *cmdWrapper) Start() error {
+	err := (*osexec.Cmd)(cmd).Start()
+	return handleError(err)
+}
+
+func (cmd *cmdWrapper) Wait() error {
+	err := (*osexec.Cmd)(cmd).Wait()
+	return handleError(err)
 }
 
 // Run is part of the Cmd interface.

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -18,6 +18,8 @@ package exec
 
 import (
 	"context"
+	"io"
+	"io/ioutil"
 	osexec "os/exec"
 	"testing"
 	"time"
@@ -160,4 +162,54 @@ func TestSetEnv(t *testing.T) {
 	if string(out) != "baz\n" {
 		t.Errorf("unexpected output: %q", string(out))
 	}
+}
+
+func TestStdIOPipes(t *testing.T) {
+	cmd := New().Command("/bin/sh", "-c", "echo 'OUT'>&1; echo 'ERR'>&2")
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("expected StdoutPipe() not to error, got: %v", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatalf("expected StderrPipe() not to error, got: %v", err)
+	}
+
+	stdout := make(chan string)
+	stderr := make(chan string)
+
+	go func() {
+		stdout <- readAll(t, stdoutPipe, "StdOut")
+	}()
+	go func() {
+		stderr <- readAll(t, stderrPipe, "StdErr")
+	}()
+
+	if err := cmd.Start(); err != nil {
+		t.Errorf("expected Start() not to error, got: %v", err)
+	}
+
+	if e, a := "OUT\n", <-stdout; e != a {
+		t.Errorf("expected StdOut to be '%s', got: '%v'", e, a)
+	}
+
+	if e, a := "ERR\n", <-stderr; e != a {
+		t.Errorf("expected StdErr to be '%s', got: '%v'", e, a)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		t.Errorf("expected Wait() not to error, got: %v", err)
+	}
+}
+
+func readAll(t *testing.T, r io.Reader, n string) string {
+	t.Helper()
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error when reading from %s: %v", n, err)
+	}
+
+	return string(b)
 }

--- a/exec/stdiopipe_test.go
+++ b/exec/stdiopipe_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec_test
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"k8s.io/utils/exec"
+)
+
+func ExampleCmd_StderrPipe() {
+	cmd := exec.New().Command("/bin/sh", "-c", "echo 'We can read from stderr via pipe!' >&2")
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		panic(err)
+	}
+
+	stderr := make(chan []byte)
+	go func() {
+		b, err := ioutil.ReadAll(stderrPipe)
+		if err != nil {
+			panic(err)
+		}
+		stderr <- b
+	}()
+
+	if err := cmd.Start(); err != nil {
+		panic(err)
+	}
+
+	received := <-stderr
+
+	if err := cmd.Wait(); err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(received))
+	// Output: We can read from stderr via pipe!
+}

--- a/exec/testing/fake_exec.go
+++ b/exec/testing/fake_exec.go
@@ -70,6 +70,10 @@ type FakeCmd struct {
 	Stdout               io.Writer
 	Stderr               io.Writer
 	Env                  []string
+	StdoutPipeResponse   FakeStdIOPipeResponse
+	StderrPipeResponse   FakeStdIOPipeResponse
+	WaitResponse         error
+	StartResponse        error
 }
 
 var _ exec.Cmd = &FakeCmd{}
@@ -78,6 +82,13 @@ var _ exec.Cmd = &FakeCmd{}
 func InitFakeCmd(fake *FakeCmd, cmd string, args ...string) exec.Cmd {
 	fake.Argv = append([]string{cmd}, args...)
 	return fake
+}
+
+// FakeStdIOPipeResponse holds responses to use as fakes for the StdoutPipe and
+// StderrPipe method calls
+type FakeStdIOPipeResponse struct {
+	ReadCloser io.ReadCloser
+	Error      error
 }
 
 // FakeCombinedOutputAction is a function type
@@ -109,6 +120,30 @@ func (fake *FakeCmd) SetStderr(out io.Writer) {
 // SetEnv sets the environment variables
 func (fake *FakeCmd) SetEnv(env []string) {
 	fake.Env = env
+}
+
+// StdoutPipe returns an injected ReadCloser & error (via StdoutPipeResponse)
+// to be able to inject an output stream on Stdout
+func (fake *FakeCmd) StdoutPipe() (io.ReadCloser, error) {
+	return fake.StdoutPipeResponse.ReadCloser, fake.StdoutPipeResponse.Error
+}
+
+// StderrPipe returns an injected ReadCloser & error (via StderrPipeResponse)
+// to be able to inject an output stream on Stderr
+func (fake *FakeCmd) StderrPipe() (io.ReadCloser, error) {
+	return fake.StderrPipeResponse.ReadCloser, fake.StderrPipeResponse.Error
+}
+
+// Start mimicks starting the process (in the background) and returns the
+// injected StartResponse
+func (fake *FakeCmd) Start() error {
+	return fake.StartResponse
+}
+
+// Wait mimicks waiting for the process to exit returns the
+// injected WaitResponse
+func (fake *FakeCmd) Wait() error {
+	return fake.WaitResponse
 }
 
 // Run sets runs the command


### PR DESCRIPTION
This change allows users to get a hold of the Std{out,err} streams of processes as `io.Reader`s. This allows e.g. to wrap those readers with a `io.limitedReader` and other standard (and non-standard) mechanisms for generic `io.Reader`s. This is currently not possible, as access to Std{out,err} is only possible via:
- handing in a `io.Writer`s
- inspecting the returned `[]byte`s from the `Output`/`CombinedOutput` methods

Specifically, we were looking into https://github.com/kubernetes/kubernetes/issues/70890 where we would jut employ an `io.limitedReader` to stop reading input after a certain amount of data.

/kind enhancement
/cc @mariantalla 