### PR TITLE
[exec] Fix godoc Example

### DIFF
--- a/exec/stdiopipe_test.go
+++ b/exec/stdiopipe_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/utils/exec"
 )
 
-func ExampleCmd_StderrPipe() {
+func ExampleNew_stderrPipe() {
 	cmd := exec.New().Command("/bin/sh", "-c", "echo 'We can read from stderr via pipe!' >&2")
 
 	stderrPipe, err := cmd.StderrPipe()


### PR DESCRIPTION
We changed the Example to document the `New` function, as this seemed to
be a better fitting place.
Using a lower-case suffix does not document a specific method of a type
but marks the example to be a generic example for that type; this also
seemed more fitting for our example.

Signed-off-by: Hannes Hörl <hhorl@pivotal.io>