### PR TITLE
k8s.io/utils should use klog

### DIFF
--- a/nsenter/exec.go
+++ b/nsenter/exec.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"k8s.io/utils/exec"
 )
 
@@ -49,7 +49,7 @@ func NewNsenterExecutor(hostRootFsPath string, executor exec.Interface) *Executo
 func (nsExecutor *Executor) Command(cmd string, args ...string) exec.Cmd {
 	fullArgs := append([]string{fmt.Sprintf("--mount=%s", nsExecutor.hostProcMountNsPath), "--"},
 		append([]string{cmd}, args...)...)
-	glog.V(5).Infof("Running nsenter command: %v %v", nsenterPath, fullArgs)
+	klog.V(5).Infof("Running nsenter command: %v %v", nsenterPath, fullArgs)
 	return nsExecutor.executor.Command(nsenterPath, fullArgs...)
 }
 
@@ -57,7 +57,7 @@ func (nsExecutor *Executor) Command(cmd string, args ...string) exec.Cmd {
 func (nsExecutor *Executor) CommandContext(ctx context.Context, cmd string, args ...string) exec.Cmd {
 	fullArgs := append([]string{fmt.Sprintf("--mount=%s", nsExecutor.hostProcMountNsPath), "--"},
 		append([]string{cmd}, args...)...)
-	glog.V(5).Infof("Running nsenter command: %v %v", nsenterPath, fullArgs)
+	klog.V(5).Infof("Running nsenter command: %v %v", nsenterPath, fullArgs)
 	return nsExecutor.executor.CommandContext(ctx, nsenterPath, fullArgs...)
 }
 

--- a/nsenter/nsenter.go
+++ b/nsenter/nsenter.go
@@ -26,9 +26,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"k8s.io/klog"
 	"k8s.io/utils/exec"
-
-	"github.com/golang/glog"
 )
 
 const (
@@ -127,7 +126,7 @@ func (ne *Nsenter) Exec(cmd string, args []string) exec.Cmd {
 	hostProcMountNsPath := filepath.Join(ne.hostRootFsPath, mountNsPath)
 	fullArgs := append([]string{fmt.Sprintf("--mount=%s", hostProcMountNsPath), "--"},
 		append([]string{ne.AbsHostPath(cmd)}, args...)...)
-	glog.V(5).Infof("Running nsenter command: %v %v", nsenterPath, fullArgs)
+	klog.V(5).Infof("Running nsenter command: %v %v", nsenterPath, fullArgs)
 	return ne.executor.Command(nsenterPath, fullArgs...)
 }
 
@@ -170,7 +169,7 @@ func (ne *Nsenter) EvalSymlinks(pathname string, mustExist bool) (string, error)
 	}
 	outBytes, err := ne.Exec("realpath", args).CombinedOutput()
 	if err != nil {
-		glog.Infof("failed to resolve symbolic links on %s: %v", pathname, err)
+		klog.Infof("failed to resolve symbolic links on %s: %v", pathname, err)
 		return "", err
 	}
 	return strings.TrimSpace(string(outBytes)), nil


### PR DESCRIPTION
Tried to update vendor in k8s.io/kubernetes and ran into error since k8s.io/utils imports glog still. 