### PR TITLE
A sketch of converting to logr

### DIFF
--- a/nsenter/exec.go
+++ b/nsenter/exec.go
@@ -23,9 +23,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/go-logr/klogr"
 	"github.com/go-logr/logr"
-
 	"k8s.io/utils/exec"
 )
 
@@ -36,44 +34,49 @@ type Executor struct {
 	// Path to the host's root proc path
 	hostProcMountNsPath string
 	// How to log
-	log logr.Logger
+	log logr.InfoLogger
 }
 
-// NewNsenterExecutor returns new nsenter based executor.  Logs will be sent via
-// k8s.io/klog unless otherwise configured (see WithLogger).
+// NewNsenterExecutor returns new nsenter based executor.  If logging is enabled
+// (see WithLogger) Executor will log executions, but will return errors without
+// logging them.
 func NewNsenterExecutor(hostRootFsPath string, executor exec.Interface) *Executor {
 	hostProcMountNsPath := filepath.Join(hostRootFsPath, mountNsPath)
 	nsExecutor := &Executor{
 		hostProcMountNsPath: hostProcMountNsPath,
 		executor:            executor,
-		log:                 klogr.New().WithName("nsenter"),
+		log:                 nil,
 	}
 	return nsExecutor
 }
 
-// WithLogger returns the same executor, but configures logging
-func (e *Executor) WithLogger(log logr.Logger) *Executor {
+// WithLogger returns the same executor, but configures it for logging.
+func (e *Executor) WithLogger(log logr.InfoLogger) *Executor {
 	e.log = log
 	return e
 }
 
-// Command returns a command wrapped with nenter
+// Command returns a command wrapped with nsenter.
 func (e *Executor) Command(cmd string, args ...string) exec.Cmd {
 	fullArgs := append([]string{fmt.Sprintf("--mount=%s", e.hostProcMountNsPath), "--"},
 		append([]string{cmd}, args...)...)
-	e.log.V(5).Info("Running nsenter", "bin", nsenterPath, "args", fullArgs)
+	if e.log != nil {
+		e.log.Info("Running nsenter", "bin", nsenterPath, "args", fullArgs)
+	}
 	return e.executor.Command(nsenterPath, fullArgs...)
 }
 
-// CommandContext returns a CommandContext wrapped with nsenter
+// CommandContext returns a CommandContext wrapped with nsenter.
 func (e *Executor) CommandContext(ctx context.Context, cmd string, args ...string) exec.Cmd {
 	fullArgs := append([]string{fmt.Sprintf("--mount=%s", e.hostProcMountNsPath), "--"},
 		append([]string{cmd}, args...)...)
-	e.log.V(5).Info("Running nsenter", "bin", nsenterPath, "args", fullArgs)
+	if e.log != nil {
+		e.log.Info("Running nsenter", "bin", nsenterPath, "args", fullArgs)
+	}
 	return e.executor.CommandContext(ctx, nsenterPath, fullArgs...)
 }
 
-// LookPath returns a LookPath wrapped with nsenter
+// LookPath returns a LookPath wrapped with nsenter.
 func (*Executor) LookPath(file string) (string, error) {
-	return "", fmt.Errorf("not implemented, error looking up : %s", file)
+	return "", fmt.Errorf("LookPath() is not supported for nsenter.Executor: %s", file)
 }


### PR DESCRIPTION
We have 2 other users - another nsenter file and trace.  I don't know
why we have 2 seemingly very similar nsenter executors - maybe we can
fix that?

If this seems reasonable I can check in a klogr implementation (just a
clone of glogr.

It would be nice to get rid of the default and not log at all unless the logger is specified.  Given that the logs are very high V anyway, it seems plausible.