### PR TITLE
keymutex: remove glog usage

### DIFF
--- a/keymutex/hashed.go
+++ b/keymutex/hashed.go
@@ -20,8 +20,6 @@ import (
 	"hash/fnv"
 	"runtime"
 	"sync"
-
-	"github.com/golang/glog"
 )
 
 // NewHashed returns a new instance of KeyMutex which hashes arbitrary keys to
@@ -44,16 +42,12 @@ type hashedKeyMutex struct {
 
 // Acquires a lock associated with the specified ID.
 func (km *hashedKeyMutex) LockKey(id string) {
-	glog.V(5).Infof("hashedKeyMutex.LockKey(...) called for id %q\r\n", id)
 	km.mutexes[km.hash(id)%len(km.mutexes)].Lock()
-	glog.V(5).Infof("hashedKeyMutex.LockKey(...) for id %q completed.\r\n", id)
 }
 
 // Releases the lock associated with the specified ID.
 func (km *hashedKeyMutex) UnlockKey(id string) error {
-	glog.V(5).Infof("hashedKeyMutex.UnlockKey(...) called for id %q\r\n", id)
 	km.mutexes[km.hash(id)%len(km.mutexes)].Unlock()
-	glog.V(5).Infof("hashedKeyMutex.UnlockKey(...) for id %q completed.\r\n", id)
 	return nil
 }
 


### PR DESCRIPTION
https://github.com/kubernetes/utils/pull/55 was merged shortly after
https://github.com/kubernetes/utils/pull/68 and then brought back
glog, which now breaks vendoring of k8s.io/utils (can't have both glog
and klog defining the same command line flags).

Instead of replacing the logging with klog, logging gets removed
entirely. The rationale is that the log output is likely to be more
useful and/or readable if it is done by the caller. This is also a
first step towards removing the klog dependency from
k8s.io/utils (https://github.com/kubernetes/utils/pull/68#issuecomment-457249328).

/assign @dims