### PR TITLE
Move object diff and field path from apimachinery

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"k8s.io/utils/field"
+)
+
+// StringDiff diffs a and b and returns a human readable diff.
+func StringDiff(a, b string) string {
+	ba := []byte(a)
+	bb := []byte(b)
+	out := []byte{}
+	i := 0
+	for ; i < len(ba) && i < len(bb); i++ {
+		if ba[i] != bb[i] {
+			break
+		}
+		out = append(out, ba[i])
+	}
+	out = append(out, []byte("\n\nA: ")...)
+	out = append(out, ba[i:]...)
+	out = append(out, []byte("\n\nB: ")...)
+	out = append(out, bb[i:]...)
+	out = append(out, []byte("\n\n")...)
+	return string(out)
+}
+
+// ObjectDiff writes the two objects out as JSON and prints out the identical part of
+// the objects followed by the remaining part of 'a' and finally the remaining part of 'b'.
+// For debugging tests.
+func ObjectDiff(a, b interface{}) string {
+	ab, err := json.Marshal(a)
+	if err != nil {
+		panic(fmt.Sprintf("a: %v", err))
+	}
+	bb, err := json.Marshal(b)
+	if err != nil {
+		panic(fmt.Sprintf("b: %v", err))
+	}
+	return StringDiff(string(ab), string(bb))
+}
+
+// ObjectGoPrintDiff is like ObjectDiff, but uses go-spew to print the objects,
+// which shows absolutely everything by recursing into every single pointer
+// (go's %#v formatters OTOH stop at a certain point). This is needed when you
+// can't figure out why reflect.DeepEqual is returning false and nothing is
+// showing you differences. This will.
+func ObjectGoPrintDiff(a, b interface{}) string {
+	s := spew.ConfigState{DisableMethods: true}
+	return StringDiff(
+		s.Sprintf("%#v", a),
+		s.Sprintf("%#v", b),
+	)
+}
+
+// ObjectReflectDiff returns a diff computed through reflection, without serializing to JSON.
+func ObjectReflectDiff(a, b interface{}) string {
+	vA, vB := reflect.ValueOf(a), reflect.ValueOf(b)
+	if vA.Type() != vB.Type() {
+		return fmt.Sprintf("type A %T and type B %T do not match", a, b)
+	}
+	diffs := objectReflectDiff(field.NewPath("object"), vA, vB)
+	if len(diffs) == 0 {
+		return "<no diffs>"
+	}
+	out := []string{""}
+	for _, d := range diffs {
+		elidedA, elidedB := limit(d.a, d.b, 80)
+		out = append(out,
+			fmt.Sprintf("%s:", d.path),
+			fmt.Sprintf("  a: %s", elidedA),
+			fmt.Sprintf("  b: %s", elidedB),
+		)
+	}
+	return strings.Join(out, "\n")
+}
+
+// limit:
+// 1. stringifies aObj and bObj
+// 2. elides identical prefixes if either is too long
+// 3. elides remaining content from the end if either is too long
+func limit(aObj, bObj interface{}, max int) (string, string) {
+	elidedPrefix := ""
+	elidedASuffix := ""
+	elidedBSuffix := ""
+	a, b := fmt.Sprintf("%#v", aObj), fmt.Sprintf("%#v", bObj)
+
+	if aObj != nil && bObj != nil {
+		if aType, bType := fmt.Sprintf("%T", aObj), fmt.Sprintf("%T", bObj); aType != bType {
+			a = fmt.Sprintf("%s (%s)", a, aType)
+			b = fmt.Sprintf("%s (%s)", b, bType)
+		}
+	}
+
+	for {
+		switch {
+		case len(a) > max && len(a) > 4 && len(b) > 4 && a[:4] == b[:4]:
+			// a is too long, b has data, and the first several characters are the same
+			elidedPrefix = "..."
+			a = a[2:]
+			b = b[2:]
+
+		case len(b) > max && len(b) > 4 && len(a) > 4 && a[:4] == b[:4]:
+			// b is too long, a has data, and the first several characters are the same
+			elidedPrefix = "..."
+			a = a[2:]
+			b = b[2:]
+
+		case len(a) > max:
+			a = a[:max]
+			elidedASuffix = "..."
+
+		case len(b) > max:
+			b = b[:max]
+			elidedBSuffix = "..."
+
+		default:
+			// both are short enough
+			return elidedPrefix + a + elidedASuffix, elidedPrefix + b + elidedBSuffix
+		}
+	}
+}
+
+func public(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	return s[:1] == strings.ToUpper(s[:1])
+}
+
+type diff struct {
+	path *field.Path
+	a, b interface{}
+}
+
+type orderedDiffs []diff
+
+func (d orderedDiffs) Len() int      { return len(d) }
+func (d orderedDiffs) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d orderedDiffs) Less(i, j int) bool {
+	a, b := d[i].path.String(), d[j].path.String()
+	if a < b {
+		return true
+	}
+	return false
+}
+
+func objectReflectDiff(path *field.Path, a, b reflect.Value) []diff {
+	switch a.Type().Kind() {
+	case reflect.Struct:
+		var changes []diff
+		for i := 0; i < a.Type().NumField(); i++ {
+			if !public(a.Type().Field(i).Name) {
+				if reflect.DeepEqual(a.Interface(), b.Interface()) {
+					continue
+				}
+				return []diff{{path: path, a: fmt.Sprintf("%#v", a), b: fmt.Sprintf("%#v", b)}}
+			}
+			if sub := objectReflectDiff(path.Child(a.Type().Field(i).Name), a.Field(i), b.Field(i)); len(sub) > 0 {
+				changes = append(changes, sub...)
+			}
+		}
+		return changes
+	case reflect.Ptr, reflect.Interface:
+		if a.IsNil() || b.IsNil() {
+			switch {
+			case a.IsNil() && b.IsNil():
+				return nil
+			case a.IsNil():
+				return []diff{{path: path, a: nil, b: b.Interface()}}
+			default:
+				return []diff{{path: path, a: a.Interface(), b: nil}}
+			}
+		}
+		return objectReflectDiff(path, a.Elem(), b.Elem())
+	case reflect.Chan:
+		if !reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+		}
+		return nil
+	case reflect.Slice:
+		lA, lB := a.Len(), b.Len()
+		l := lA
+		if lB < lA {
+			l = lB
+		}
+		if lA == lB && lA == 0 {
+			if a.IsNil() != b.IsNil() {
+				return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+			}
+			return nil
+		}
+		var diffs []diff
+		for i := 0; i < l; i++ {
+			if !reflect.DeepEqual(a.Index(i), b.Index(i)) {
+				diffs = append(diffs, objectReflectDiff(path.Index(i), a.Index(i), b.Index(i))...)
+			}
+		}
+		for i := l; i < lA; i++ {
+			diffs = append(diffs, diff{path: path.Index(i), a: a.Index(i), b: nil})
+		}
+		for i := l; i < lB; i++ {
+			diffs = append(diffs, diff{path: path.Index(i), a: nil, b: b.Index(i)})
+		}
+		return diffs
+	case reflect.Map:
+		if reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return nil
+		}
+		aKeys := make(map[interface{}]interface{})
+		for _, key := range a.MapKeys() {
+			aKeys[key.Interface()] = a.MapIndex(key).Interface()
+		}
+		var missing []diff
+		for _, key := range b.MapKeys() {
+			if _, ok := aKeys[key.Interface()]; ok {
+				delete(aKeys, key.Interface())
+				if reflect.DeepEqual(a.MapIndex(key).Interface(), b.MapIndex(key).Interface()) {
+					continue
+				}
+				missing = append(missing, objectReflectDiff(path.Key(fmt.Sprintf("%s", key.Interface())), a.MapIndex(key), b.MapIndex(key))...)
+				continue
+			}
+			missing = append(missing, diff{path: path.Key(fmt.Sprintf("%s", key.Interface())), a: nil, b: b.MapIndex(key).Interface()})
+		}
+		for key, value := range aKeys {
+			missing = append(missing, diff{path: path.Key(fmt.Sprintf("%s", key)), a: value, b: nil})
+		}
+		if len(missing) == 0 {
+			missing = append(missing, diff{path: path, a: a.Interface(), b: b.Interface()})
+		}
+		sort.Sort(orderedDiffs(missing))
+		return missing
+	default:
+		if reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return nil
+		}
+		if !a.CanInterface() {
+			return []diff{{path: path, a: fmt.Sprintf("%#v", a), b: fmt.Sprintf("%#v", b)}}
+		}
+		return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+	}
+}
+
+// ObjectGoPrintSideBySide prints a and b as textual dumps side by side,
+// enabling easy visual scanning for mismatches.
+func ObjectGoPrintSideBySide(a, b interface{}) string {
+	s := spew.ConfigState{
+		Indent: " ",
+		// Extra deep spew.
+		DisableMethods: true,
+	}
+	sA := s.Sdump(a)
+	sB := s.Sdump(b)
+
+	linesA := strings.Split(sA, "\n")
+	linesB := strings.Split(sB, "\n")
+	width := 0
+	for _, s := range linesA {
+		l := len(s)
+		if l > width {
+			width = l
+		}
+	}
+	for _, s := range linesB {
+		l := len(s)
+		if l > width {
+			width = l
+		}
+	}
+	buf := &bytes.Buffer{}
+	w := tabwriter.NewWriter(buf, width, 0, 1, ' ', 0)
+	max := len(linesA)
+	if len(linesB) > max {
+		max = len(linesB)
+	}
+	for i := 0; i < max; i++ {
+		var a, b string
+		if i < len(linesA) {
+			a = linesA[i]
+		}
+		if i < len(linesB) {
+			b = linesB[i]
+		}
+		fmt.Fprintf(w, "%s\t%s\n", a, b)
+	}
+	w.Flush()
+	return buf.String()
+}

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"testing"
+)
+
+func TestObjectReflectDiff(t *testing.T) {
+	type struct1 struct{ A []int }
+
+	testCases := map[string]struct {
+		a, b interface{}
+		out  string
+	}{
+		"map": {
+			a: map[string]int{},
+			b: map[string]int{},
+		},
+		"detect nil map": {
+			a: map[string]int(nil),
+			b: map[string]int{},
+			out: `
+object:
+  a: map[string]int(nil)
+  b: map[string]int{}`,
+		},
+		"detect map changes": {
+			a: map[string]int{"test": 1, "other": 2},
+			b: map[string]int{"test": 2, "third": 3},
+			out: `
+object[other]:
+  a: 2
+  b: <nil>
+object[test]:
+  a: 1
+  b: 2
+object[third]:
+  a: <nil>
+  b: 3`,
+		},
+		"nil slice":   {a: struct1{A: nil}, b: struct1{A: nil}},
+		"empty slice": {a: struct1{A: []int{}}, b: struct1{A: []int{}}},
+		"detect slice changes 1": {a: struct1{A: []int{1}}, b: struct1{A: []int{2}}, out: `
+object.A[0]:
+  a: 1
+  b: 2`,
+		},
+		"detect slice changes 2": {a: struct1{A: []int{}}, b: struct1{A: []int{2}}, out: `
+object.A[0]:
+  a: <nil>
+  b: 2`,
+		},
+		"detect slice changes 3": {a: struct1{A: []int{1}}, b: struct1{A: []int{}}, out: `
+object.A[0]:
+  a: 1
+  b: <nil>`,
+		},
+		"detect nil vs empty slices": {a: struct1{A: nil}, b: struct1{A: []int{}}, out: `
+object.A:
+  a: []int(nil)
+  b: []int{}`,
+		},
+		"display type differences": {a: []interface{}{int64(1)}, b: []interface{}{uint64(1)}, out: `
+object[0]:
+  a: 1 (int64)
+  b: 0x1 (uint64)`,
+		},
+	}
+	for name, test := range testCases {
+		expect := test.out
+		if len(expect) == 0 {
+			expect = "<no diffs>"
+		}
+		if actual := ObjectReflectDiff(test.a, test.b); actual != expect {
+			t.Errorf("%s: unexpected output: %s", name, actual)
+		}
+	}
+}
+
+func TestStringDiff(t *testing.T) {
+	diff := StringDiff("aaabb", "aaacc")
+	expect := "aaa\n\nA: bb\n\nB: cc\n\n"
+	if diff != expect {
+		t.Errorf("diff returned %v", diff)
+	}
+}
+
+func TestLimit(t *testing.T) {
+	testcases := []struct {
+		a       interface{}
+		b       interface{}
+		expectA string
+		expectB string
+	}{
+		{
+			a:       `short a`,
+			b:       `short b`,
+			expectA: `"short a"`,
+			expectB: `"short b"`,
+		},
+		{
+			a:       `short a`,
+			b:       `long b needs truncating`,
+			expectA: `"short a"`,
+			expectB: `"long b ne...`,
+		},
+		{
+			a:       `long a needs truncating`,
+			b:       `long b needs truncating`,
+			expectA: `...g a needs ...`,
+			expectB: `...g b needs ...`,
+		},
+		{
+			a:       `long common prefix with different stuff at the end of a`,
+			b:       `long common prefix with different stuff at the end of b`,
+			expectA: `...end of a"`,
+			expectB: `...end of b"`,
+		},
+		{
+			a:       `long common prefix with different stuff at the end of a`,
+			b:       `long common prefix with different stuff at the end of b which continues`,
+			expectA: `...of a"`,
+			expectB: `...of b which...`,
+		},
+	}
+
+	for _, tc := range testcases {
+		a, b := limit(tc.a, tc.b, 10)
+		if a != tc.expectA || b != tc.expectB {
+			t.Errorf("limit(%q, %q)\n\texpected: %s, %s\n\tgot:      %s, %s", tc.a, tc.b, tc.expectA, tc.expectB, a, b)
+		}
+	}
+}

--- a/field/path.go
+++ b/field/path.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package field
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+// Path represents the path from some root to a particular field.
+type Path struct {
+	name   string // the name of this field or "" if this is an index
+	index  string // if name == "", this is a subscript (index or map key) of the previous element
+	parent *Path  // nil if this is the root element
+}
+
+// NewPath creates a root Path object.
+func NewPath(name string, moreNames ...string) *Path {
+	r := &Path{name: name, parent: nil}
+	for _, anotherName := range moreNames {
+		r = &Path{name: anotherName, parent: r}
+	}
+	return r
+}
+
+// Root returns the root element of this Path.
+func (p *Path) Root() *Path {
+	for ; p.parent != nil; p = p.parent {
+		// Do nothing.
+	}
+	return p
+}
+
+// Child creates a new Path that is a child of the method receiver.
+func (p *Path) Child(name string, moreNames ...string) *Path {
+	r := NewPath(name, moreNames...)
+	r.Root().parent = p
+	return r
+}
+
+// Index indicates that the previous Path is to be subscripted by an int.
+// This sets the same underlying value as Key.
+func (p *Path) Index(index int) *Path {
+	return &Path{index: strconv.Itoa(index), parent: p}
+}
+
+// Key indicates that the previous Path is to be subscripted by a string.
+// This sets the same underlying value as Index.
+func (p *Path) Key(key string) *Path {
+	return &Path{index: key, parent: p}
+}
+
+// String produces a string representation of the Path.
+func (p *Path) String() string {
+	// make a slice to iterate
+	elems := []*Path{}
+	for ; p != nil; p = p.parent {
+		elems = append(elems, p)
+	}
+
+	// iterate, but it has to be backwards
+	buf := bytes.NewBuffer(nil)
+	for i := range elems {
+		p := elems[len(elems)-1-i]
+		if p.parent != nil && len(p.name) > 0 {
+			// This is either the root or it is a subscript.
+			buf.WriteString(".")
+		}
+		if len(p.name) > 0 {
+			buf.WriteString(p.name)
+		} else {
+			fmt.Fprintf(buf, "[%s]", p.index)
+		}
+	}
+	return buf.String()
+}

--- a/field/path_test.go
+++ b/field/path_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package field
+
+import "testing"
+
+func TestPath(t *testing.T) {
+	testCases := []struct {
+		op       func(*Path) *Path
+		expected string
+	}{
+		{
+			func(p *Path) *Path { return p },
+			"root",
+		},
+		{
+			func(p *Path) *Path { return p.Child("first") },
+			"root.first",
+		},
+		{
+			func(p *Path) *Path { return p.Child("second") },
+			"root.first.second",
+		},
+		{
+			func(p *Path) *Path { return p.Index(0) },
+			"root.first.second[0]",
+		},
+		{
+			func(p *Path) *Path { return p.Child("third") },
+			"root.first.second[0].third",
+		},
+		{
+			func(p *Path) *Path { return p.Index(93) },
+			"root.first.second[0].third[93]",
+		},
+		{
+			func(p *Path) *Path { return p.parent },
+			"root.first.second[0].third",
+		},
+		{
+			func(p *Path) *Path { return p.parent },
+			"root.first.second[0]",
+		},
+		{
+			func(p *Path) *Path { return p.Key("key") },
+			"root.first.second[0][key]",
+		},
+	}
+
+	root := NewPath("root")
+	p := root
+	for i, tc := range testCases {
+		p = tc.op(p)
+		if p.String() != tc.expected {
+			t.Errorf("[%d] Expected %q, got %q", i, tc.expected, p.String())
+		}
+		if p.Root() != root {
+			t.Errorf("[%d] Wrong root: %#v", i, p.Root())
+		}
+	}
+}
+
+func TestPathMultiArg(t *testing.T) {
+	testCases := []struct {
+		op       func(*Path) *Path
+		expected string
+	}{
+		{
+			func(p *Path) *Path { return p },
+			"root.first",
+		},
+		{
+			func(p *Path) *Path { return p.Child("second", "third") },
+			"root.first.second.third",
+		},
+		{
+			func(p *Path) *Path { return p.Index(0) },
+			"root.first.second.third[0]",
+		},
+		{
+			func(p *Path) *Path { return p.parent },
+			"root.first.second.third",
+		},
+		{
+			func(p *Path) *Path { return p.parent },
+			"root.first.second",
+		},
+		{
+			func(p *Path) *Path { return p.parent },
+			"root.first",
+		},
+		{
+			func(p *Path) *Path { return p.parent },
+			"root",
+		},
+	}
+
+	root := NewPath("root", "first")
+	p := root
+	for i, tc := range testCases {
+		p = tc.op(p)
+		if p.String() != tc.expected {
+			t.Errorf("[%d] Expected %q, got %q", i, tc.expected, p.String())
+		}
+		if p.Root() != root.Root() {
+			t.Errorf("[%d] Wrong root: %#v", i, p.Root())
+		}
+	}
+}


### PR DESCRIPTION
Both packages are not apimachinery specific, but totally generic (and e.g. useful in k/kube-openapi).