### PR TITLE
fix negative slice index error in keymutex

### DIFF
--- a/keymutex/hashed.go
+++ b/keymutex/hashed.go
@@ -42,17 +42,17 @@ type hashedKeyMutex struct {
 
 // Acquires a lock associated with the specified ID.
 func (km *hashedKeyMutex) LockKey(id string) {
-	km.mutexes[km.hash(id)%len(km.mutexes)].Lock()
+	km.mutexes[km.hash(id)%uint32(len(km.mutexes))].Lock()
 }
 
 // Releases the lock associated with the specified ID.
 func (km *hashedKeyMutex) UnlockKey(id string) error {
-	km.mutexes[km.hash(id)%len(km.mutexes)].Unlock()
+	km.mutexes[km.hash(id)%uint32(len(km.mutexes))].Unlock()
 	return nil
 }
 
-func (km *hashedKeyMutex) hash(id string) int {
+func (km *hashedKeyMutex) hash(id string) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(id))
-	return int(h.Sum32())
+	return h.Sum32()
 }


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/73858

The keymutex's slice index could be negative which should not happened.
This PR aims to make the index always positive.

/assign @thockin @dims