### PR TITLE
Merge interrupt history from Kubernetes into k8s.io/utils 

### DIFF
--- a/interrupt/doc.go
+++ b/interrupt/doc.go
@@ -17,5 +17,6 @@ limitations under the License.
 // Package interrupt provides a wrapper for handling signals from
 // the operating system that guarantee cleanup and exit semantics.
 // This allows a command to intercept CTRL+C or SIGTERM and do
-// the right thing before exiting.
+// the right thing before exiting. See `New()` for more information
+// about what signals are caught and how to handle them.
 package interrupt

--- a/interrupt/interrupt.go
+++ b/interrupt/interrupt.go
@@ -23,7 +23,7 @@ import (
 	"syscall"
 )
 
-// terminationSignals are signals that cause the program to exit in the
+// terminationSignals are the default signals that cause the program to exit in the
 // supported platforms (linux, darwin, windows).
 var terminationSignals = []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT}
 
@@ -50,7 +50,9 @@ func Chain(handler *Handler, notify ...func()) *Handler {
 // New creates a new handler that guarantees all notify functions are run after the critical
 // section exits (or is interrupted by the OS), then invokes the final handler. If no final
 // handler is specified, the default final is `os.Exit(1)`. A handler can only be used for
-// one critical section.
+// one critical section. The final handler is given complete control over reacting to the
+// signal - it may exit the process or ignore the signal as needed. The following signals
+// are watched: SIGHUP, SIGINT, SIGTERM, and SIGQUIT.
 func New(final func(os.Signal), notify ...func()) *Handler {
 	return &Handler{
 		final:  final,


### PR DESCRIPTION
This is picking up the work from https://github.com/kubernetes/utils/pull/47 with comments from @thockin addressed. I've copied the last comments from Tim inline to continue discussion. I would like to merge that so we can continue with kubectl extraction from k/k (https://github.com/kubernetes/kubernetes/pull/75516)

/assign @thockin @dims @smarterclayton 
/cc @seans3 