### PR TITLE
limit for mutex

### DIFF
--- a/keymutex/hashed.go
+++ b/keymutex/hashed.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 )
 
+const threshold = 1e6
+
 // NewHashed returns a new instance of KeyMutex which hashes arbitrary keys to
 // a fixed set of locks. `n` specifies number of locks, if n <= 0, we use
 // number of cpus.
@@ -30,6 +32,9 @@ import (
 func NewHashed(n int) KeyMutex {
 	if n <= 0 {
 		n = runtime.NumCPU()
+	}
+	if n > threshold {
+		n = threshold
 	}
 	return &hashedKeyMutex{
 		mutexes: make([]sync.Mutex, n),


### PR DESCRIPTION
we should set limit for mutex number ,avoid too many mutex decrease performance

below is a benchmark result（My macbook is 6c16g）

```
goos: darwin
goarch: amd64
pkg: klock

// NewHashed(0)
Benchmark8sKeymutex-12             20000             99119 ns/op            8992 B/op       1029 allocs/op

// NewHashed(1e1)
Benchmark8sKeymutex1-12            20000             97990 ns/op            8683 B/op       1026 allocs/op

// NewHashed(1e2)
Benchmark8sKeymutex2-12            20000             97164 ns/op            8507 B/op       1024 allocs/op

// NewHashed(1e4)
Benchmark8sKeymutex4-12            20000             99783 ns/op            8512 B/op       1024 allocs/op

// NewHashed(1e6)
Benchmark8sKeymutex6-12            20000             98473 ns/op            8816 B/op       1023 allocs/op

// NewHashed(1e7)
Benchmark8sKeymutex7-12            20000            100156 ns/op           12269 B/op       1021 allocs/op

// NewHashed(1e8)
Benchmark8sKeymutex8-12            20000            102076 ns/op           48211 B/op       1020 allocs/op
```
So 1e6 seems a reasonable threshold to set