### PR TITLE
Add Trace example and update documentation

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -43,7 +43,8 @@ func New(name string) *Trace {
 	return &Trace{name, time.Now(), nil}
 }
 
-// Step adds a new step with a specific message
+// Step adds a new step with a specific message. Call this at the end of an
+// execution step to record how long it took.
 func (t *Trace) Step(msg string) {
 	if t.steps == nil {
 		// traces almost always have less than 6 steps, do this to avoid more than a single allocation

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -18,6 +18,7 @@ package trace
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -197,4 +198,17 @@ func TestLogIfLong(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ExampleTrace_Step() {
+	t := New("frobber")
+
+	time.Sleep(5 * time.Millisecond)
+	t.Step("reticulated splines") // took 5ms
+
+	time.Sleep(10 * time.Millisecond)
+	t.Step("sequenced particles") // took 10ms
+
+	klog.SetOutput(os.Stdout) // change output from stderr to stdout
+	t.Log()
 }


### PR DESCRIPTION
There are users of the trace library who call `Step()` at the
*beginning* of a step rather than the end, resulting in some confusing
logs. This updates examples and docs to clarify.

/kind cleanup
/kind documentation