### PR TITLE
Adds support for initializing Trace with output options defined.

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -19,6 +19,7 @@ package trace
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"math/rand"
 	"time"
 
@@ -41,6 +42,13 @@ type Trace struct {
 // New creates a Trace with the specified name
 func New(name string) *Trace {
 	return &Trace{name, time.Now(), nil}
+}
+
+// NewWithOutput creates a Trace with the specified name and klog output options defined
+func NewWithOutput(name string, writer io.Writer) *Trace {
+	// allows libraries to apply tracing and view output without declaring klog
+	klog.SetOutput(writer)
+	return New(name)
 }
 
 // Step adds a new step with a specific message. Call this at the end of an

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -82,6 +82,34 @@ func TestTotalTime(t *testing.T) {
 	})
 }
 
+func TestForEmptyOutput(t *testing.T) {
+	test := struct {
+		name        string
+		sampleTrace *Trace
+	}{
+		name: "Check there is no log output written",
+	}
+
+	t.Run(test.name, func(t *testing.T) {
+		var buf bytes.Buffer
+
+		trace := NewWithOutput("testoutputopts", &buf)
+
+		trace.steps = []traceStep{
+			{time.Now(), "msg1"},
+			{time.Now(), "msg2"},
+			{time.Now(), "msg3"},
+		}
+
+		trace.Log()
+
+		if buf.Len() == 0 {
+			t.Errorf("\nLogs writen to buffer were not found. %v", buf.Len())
+		}
+	})
+
+}
+
 func TestLog(t *testing.T) {
 	test := struct {
 		name             string


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows the `k8s.io/utils/trace` library to be functional for downstream projects by adding an additional initializer that supports defining klog output options. With this new k8s libraries can get prototyped without being explicit with klog.

Example of no output written.

```
var (
	a int32
	b int32
)

func math(t *utiltrace.Trace) {
	t.Step("math func")

	a = 2
	b = 4

	sum := a + b

	t.Step(fmt.Sprintf("This is the sum: %v", sum))
}

func main() {

	trace := utiltrace.New("Init tracing")

	math(trace)

	trace.Log()

}
```

**Does this PR introduce a user-facing change?**:
`NONE`

**Special notes for your reviewer**:
Test included