### PR TITLE
net: add GetHostname API

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -17,8 +17,11 @@ limitations under the License.
 package net
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"os"
+	"strings"
 )
 
 // ParseCIDRs parses a list of cidrs and return error if any is invalid.
@@ -131,4 +134,24 @@ func IsIPv6CIDRString(cidr string) bool {
 func IsIPv6CIDR(cidr *net.IPNet) bool {
 	ip := cidr.IP
 	return IsIPv6(ip)
+}
+
+// GetHostname returns OS's hostname if 'hostnameOverride' is empty; otherwise, return 'hostnameOverride'
+func GetHostname(hostnameOverride string) (string, error) {
+	hostName := hostnameOverride
+	if len(hostName) == 0 {
+		nodeName, err := os.Hostname()
+		if err != nil {
+			return "", fmt.Errorf("couldn't determine hostname: %v", err)
+		}
+		hostName = nodeName
+	}
+
+	// Trim whitespaces first to avoid getting an empty hostname
+	// For linux, the hostname is read from file /proc/sys/kernel/hostname directly
+	hostName = strings.TrimSpace(hostName)
+	if len(hostName) == 0 {
+		return "", errors.New("empty hostname is invalid")
+	}
+	return strings.ToLower(hostName), nil
 }

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package net
 
 import (
+	"errors"
 	"net"
+	"os"
 	"testing"
 )
 
@@ -445,5 +447,53 @@ func TestIsIPv6CIDR(t *testing.T) {
 		if res != tc.expectResult {
 			t.Errorf("%v: want IsIPv6CIDR=%v, got %v", tc.desc, tc.expectResult, res)
 		}
+	}
+}
+
+func TestGetHostname(t *testing.T) {
+	hostname, err := os.Hostname()
+
+	testCases := []struct {
+		desc        string
+		hostname    string
+		result      string
+		expectedErr error
+	}{
+		{
+			desc:        "overriden hostname",
+			hostname:    "overriden",
+			result:      "overriden",
+			expectedErr: nil,
+		},
+		{
+			desc:        "hostname contains only spaces",
+			hostname:    " ",
+			result:      "",
+			expectedErr: errors.New("empty hostname is invalid"),
+		},
+		{
+			desc:        "empty parameter",
+			hostname:    "",
+			result:      hostname,
+			expectedErr: err,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result, err := GetHostname(tc.hostname)
+
+			if err != nil && tc.expectedErr == nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if err == nil && tc.expectedErr != nil {
+				t.Errorf("expected error %v, got nil", tc.expectedErr)
+			}
+
+			if tc.result != result {
+				t.Errorf("unexpected result: %s, expected: %s", result, tc.result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Copied GetHostname API from k/k/pkg/util/node to use in
Kubernetes components outside of Kubernetes core.

This PR is pre-requisite for removing kubeadm dependency to pkg/util/node.
See more details in [this issue](https://github.com/kubernetes/kubeadm/issues/1600)