### PR TITLE
add procfs APIs

### DIFF
--- a/procfs/doc.go
+++ b/procfs/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package procfs implements utility functions relating to the /proc mount.
+package procfs // import "k8s.io/utils/procfs"

--- a/procfs/example_proc_cgroup
+++ b/procfs/example_proc_cgroup
@@ -1,0 +1,10 @@
+11:name=systemd:/user/1000.user/c1.session
+10:hugetlb:/user/1000.user/c1.session
+9:perf_event:/user/1000.user/c1.session
+8:blkio:/user/1000.user/c1.session
+7:freezer:/user/1000.user/c1.session
+6:devices:/user/1000.user/c1.session
+5:memory:/user/1000.user/c1.session
+4:cpuacct:/user/1000.user/c1.session
+3:cpu:/user/1000.user/c1.session
+2:cpuset:/

--- a/procfs/procfs.go
+++ b/procfs/procfs.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package procfs
+
+// ProcInterface that presents GetFullContainerName API implemented
+// by ProcFS and FakeProcFS
+type ProcInterface interface {
+	// GetFullContainerName gets the container name given the root process id of the container.
+	GetFullContainerName(pid int) (string, error)
+}

--- a/procfs/procfs_fake.go
+++ b/procfs/procfs_fake.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package procfs
+
+// FakeProcFS implements ProcInterface
+type FakeProcFS struct{}
+
+// NewFakeProcFS creates FakeProcFS object
+func NewFakeProcFS() ProcInterface {
+	return &FakeProcFS{}
+}
+
+// GetFullContainerName gets the container name given the root process id of the container.
+// E.g. if the devices cgroup for the container is stored in /sys/fs/cgroup/devices/docker/nginx,
+// return docker/nginx. Assumes that the process is part of exactly one cgroup hierarchy.
+func (fakePfs *FakeProcFS) GetFullContainerName(pid int) (string, error) {
+	return "", nil
+}

--- a/procfs/procfs_linux.go
+++ b/procfs/procfs_linux.go
@@ -1,0 +1,180 @@
+// +build linux
+
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package procfs
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"unicode"
+
+	"k8s.io/klog"
+)
+
+// ProcFS implements ProcInterface
+type ProcFS struct{}
+
+// NewProcFS creates ProcFS object
+func NewProcFS() ProcInterface {
+	return &ProcFS{}
+}
+
+func containerNameFromProcCgroup(content string) (string, error) {
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		entries := strings.SplitN(line, ":", 3)
+		if len(entries) == 3 && entries[1] == "devices" {
+			return strings.TrimSpace(entries[2]), nil
+		}
+	}
+	return "", fmt.Errorf("could not find devices cgroup location")
+}
+
+// GetFullContainerName gets the container name given the root process id of the container.
+// E.g. if the devices cgroup for the container is stored in /sys/fs/cgroup/devices/docker/nginx,
+// return docker/nginx. Assumes that the process is part of exactly one cgroup hierarchy.
+func (pfs *ProcFS) GetFullContainerName(pid int) (string, error) {
+	filePath := path.Join("/proc", strconv.Itoa(pid), "cgroup")
+	content, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", os.ErrNotExist
+		}
+		return "", err
+	}
+	return containerNameFromProcCgroup(string(content))
+}
+
+// PKill finds process(es) using a regular expression
+// and sends a specified signal to each process
+func PKill(name string, sig syscall.Signal) error {
+	if len(name) == 0 {
+		return fmt.Errorf("name should not be empty")
+	}
+	re, err := regexp.Compile(name)
+	if err != nil {
+		return err
+	}
+	pids := getPids(re)
+	if len(pids) == 0 {
+		return fmt.Errorf("unable to fetch pids for process name : %q", name)
+	}
+	var errmsgs []string
+	for _, pid := range pids {
+		if err = syscall.Kill(pid, sig); err != nil {
+			msg := err.Error()
+			for _, item := range errmsgs {
+				if item == msg {
+					goto Skip
+				}
+			}
+			errmsgs = append(errmsgs, msg)
+		Skip:
+		}
+	}
+	numErrors := len(errmsgs)
+	if numErrors > 0 {
+		if numErrors == 1 {
+			return fmt.Errorf(errmsgs[0])
+		}
+		return fmt.Errorf("[ %s ]", strings.Join(errmsgs, ","))
+	}
+	return nil
+}
+
+// PidOf finds process(es) with a specified name (regexp match)
+// and returns their pid(s)
+func PidOf(name string) ([]int, error) {
+	if len(name) == 0 {
+		return []int{}, fmt.Errorf("name should not be empty")
+	}
+	re, err := regexp.Compile("(^|/)" + name + "$")
+	if err != nil {
+		return []int{}, err
+	}
+	return getPids(re), nil
+}
+
+func getPids(re *regexp.Regexp) []int {
+	pids := []int{}
+
+	dirFD, err := os.Open("/proc")
+	if err != nil {
+		return nil
+	}
+	defer dirFD.Close()
+
+	for {
+		// Read a small number at a time in case there are many entries, we don't want to
+		// allocate a lot here.
+		ls, err := dirFD.Readdir(10)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil
+		}
+
+		for _, entry := range ls {
+			if !entry.IsDir() {
+				continue
+			}
+
+			// If the directory is not a number (i.e. not a PID), skip it
+			pid, err := strconv.Atoi(entry.Name())
+			if err != nil {
+				continue
+			}
+
+			cmdline, err := ioutil.ReadFile(filepath.Join("/proc", entry.Name(), "cmdline"))
+			if err != nil {
+				klog.V(4).Infof("Error reading file %s: %+v", filepath.Join("/proc", entry.Name(), "cmdline"), err)
+				continue
+			}
+
+			// The bytes we read have '\0' as a separator for the command line
+			parts := bytes.SplitN(cmdline, []byte{0}, 2)
+			if len(parts) == 0 {
+				continue
+			}
+			// Split the command line itself we are interested in just the first part
+			exe := strings.FieldsFunc(string(parts[0]), func(c rune) bool {
+				return unicode.IsSpace(c) || c == ':'
+			})
+			if len(exe) == 0 {
+				continue
+			}
+			// Check if the name of the executable is what we are looking for
+			if re.MatchString(exe[0]) {
+				// Grab the PID from the directory path
+				pids = append(pids, pid)
+			}
+		}
+	}
+
+	return pids
+}

--- a/procfs/procfs_linux_test.go
+++ b/procfs/procfs_linux_test.go
@@ -1,0 +1,116 @@
+// +build linux
+
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package procfs
+
+import (
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func verifyContainerName(procCgroupText, expectedName string, expectedErr bool, t *testing.T) {
+	name, err := containerNameFromProcCgroup(procCgroupText)
+	if expectedErr && err == nil {
+		t.Errorf("Expected error but did not get error in verifyContainerName")
+		return
+	} else if !expectedErr && err != nil {
+		t.Errorf("Expected no error, but got error %+v in verifyContainerName", err)
+		return
+	} else if expectedErr {
+		return
+	}
+	if name != expectedName {
+		t.Errorf("Expected container name %s but got name %s", expectedName, name)
+	}
+}
+
+func TestContainerNameFromProcCgroup(t *testing.T) {
+	procCgroupValid := "2:devices:docker/kubelet"
+	verifyContainerName(procCgroupValid, "docker/kubelet", false, t)
+
+	procCgroupEmpty := ""
+	verifyContainerName(procCgroupEmpty, "", true, t)
+
+	content, err := ioutil.ReadFile("example_proc_cgroup")
+	if err != nil {
+		t.Errorf("Could not read example /proc cgroup file")
+	}
+	verifyContainerName(string(content), "/user/1000.user/c1.session", false, t)
+
+	procCgroupNoDevice := "2:freezer:docker/kubelet\n5:cpuacct:pkg/kubectl"
+	verifyContainerName(procCgroupNoDevice, "", true, t)
+
+	procCgroupInvalid := "devices:docker/kubelet\ncpuacct:pkg/kubectl"
+	verifyContainerName(procCgroupInvalid, "", true, t)
+}
+
+func TestPidOf(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skipf("not supported on GOOS=%s", runtime.GOOS)
+	}
+	pids, err := PidOf(filepath.Base(os.Args[0]))
+	assert.Empty(t, err)
+	assert.NotZero(t, pids)
+	assert.Contains(t, pids, os.Getpid())
+}
+
+func TestPKill(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skipf("not supported on GOOS=%s", runtime.GOOS)
+	}
+	sig := syscall.SIGCONT
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, sig)
+	defer signal.Stop(c)
+	PKill(os.Args[0], sig)
+	select {
+	case s := <-c:
+		if s != sig {
+			t.Fatalf("signal was %v, want %v", s, sig)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timeout waiting for %v", sig)
+	}
+}
+
+func BenchmarkGetPids(b *testing.B) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		b.Skipf("not supported on GOOS=%s", runtime.GOOS)
+	}
+
+	re, err := regexp.Compile("(^|/)" + filepath.Base(os.Args[0]) + "$")
+	assert.Empty(b, err)
+
+	for i := 0; i < b.N; i++ {
+		pids := getPids(re)
+
+		b.StopTimer()
+		assert.NotZero(b, pids)
+		assert.Contains(b, pids, os.Getpid())
+		b.StartTimer()
+	}
+}

--- a/procfs/procfs_unsupported.go
+++ b/procfs/procfs_unsupported.go
@@ -1,0 +1,47 @@
+// +build !linux
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package procfs
+
+import (
+	"fmt"
+	"syscall"
+)
+
+type ProcFS struct{}
+
+func NewProcFS() ProcInterface {
+	return &ProcFS{}
+}
+
+// GetFullContainerName gets the container name given the root process id of the container.
+func (pfs *ProcFS) GetFullContainerName(pid int) (string, error) {
+	return "", fmt.Errorf("GetFullContainerName is unsupported in this build")
+}
+
+// PKill finds process(es) using a regular expression
+// and sends a specified signal to each process
+func PKill(name string, sig syscall.Signal) error {
+	return fmt.Errorf("PKill is unsupported in this build")
+}
+
+// PidOf finds process(es) with a specified name (regexp match)
+// and returns their pid(s)
+func PidOf(name string) ([]int, error) {
+	return []int{}, fmt.Errorf("PidOf is unsupported in this build")
+}


### PR DESCRIPTION
This module is copied from k/k/pkg/util/procfs to use in
Kubernetes components outside of Kubernetes core

These changes have been done for the original source code
mainly to pass kubernetes/utils checks and avoid bringing additional
dependencies to the package:

- Added comments to fix golint warnings:
```
  procfs/procfs.go:19:6: exported type ProcFSInterface should have comment or be unexported
  procfs/procfs_fake.go:19:6: exported type FakeProcFS should have comment or be unexported
  procfs/procfs_fake.go:21:1: exported function NewFakeProcFS should have comment or be unexported
  procfs/procfs_linux.go:39:6: exported type ProcFS should have comment or be unexported
  procfs/procfs_linux.go:41:1: exported function NewProcFS should have comment or be unexported
  procfs/procfs_linux.go:56:1: comment on exported method ProcFS.GetFullContainerName should be of the form "GetFullContainerName ..."
  procfs/procfs_linux.go:71:1: comment on exported function PKill should be of the form "PKill ..."
  procfs/procfs_linux.go:94:1: comment on exported function PidOf should be of the form "PidOf ..."
```
- Renamed ProcFSInterface to ProcInterface to fix
  golint warning:
```
    procfs/procfs.go:21:6: type name will be used as procfs.ProcFSInterfaceby other packages, and that stutters; consider calling this Interface
```
- Got rid of dependency to
  k8s.io/apimachinery/pkg/util/errors:NewAggregate API

This PR is pre-requisite for removing kubeadm dependency to pkg/util/procfs.
See more details in [this issue](https://github.com/kubernetes/kubeadm/issues/1600) and [this PR](https://github.com/kubernetes/kubernetes/pull/80296)