### PR TITLE
Add fields to trace to allow for consistent paramaterization and to avoid needless string concatenation

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -25,32 +25,55 @@ import (
 	"k8s.io/klog"
 )
 
+// Field is a key value pair that provides additional details about the trace.
+type Field struct {
+	Key   string
+	Value interface{}
+}
+
+func (f Field) format() string {
+	return fmt.Sprintf("%s:%v", f.Key, f.Value)
+}
+
+func writeFields(b *bytes.Buffer, l []Field) {
+	for i, f := range l {
+		b.WriteString(f.format())
+		if i < len(l)-1 {
+			b.WriteString(",")
+		}
+	}
+}
+
 type traceStep struct {
 	stepTime time.Time
 	msg      string
+	fields   []Field
 }
 
 // Trace keeps track of a set of "steps" and allows us to log a specific
 // step if it took longer than its share of the total allowed time
 type Trace struct {
 	name      string
+	fields    []Field
 	startTime time.Time
 	steps     []traceStep
 }
 
-// New creates a Trace with the specified name
-func New(name string) *Trace {
-	return &Trace{name, time.Now(), nil}
+// New creates a Trace with the specified name. The name identifies the operation to be traced. The
+// Fields add key value pairs to provide additional details about the trace, such as operation inputs.
+func New(name string, fields ...Field) *Trace {
+	return &Trace{name: name, startTime: time.Now(), fields: fields}
 }
 
-// Step adds a new step with a specific message. Call this at the end of an
-// execution step to record how long it took.
-func (t *Trace) Step(msg string) {
+// Step adds a new step with a specific message. Call this at the end of an execution step to record
+// how long it took. The Fields add key value pairs to provide additional details about the trace
+// step.
+func (t *Trace) Step(msg string, fields ...Field) {
 	if t.steps == nil {
 		// traces almost always have less than 6 steps, do this to avoid more than a single allocation
 		t.steps = make([]traceStep, 0, 6)
 	}
-	t.steps = append(t.steps, traceStep{time.Now(), msg})
+	t.steps = append(t.steps, traceStep{stepTime: time.Now(), msg: msg, fields: fields})
 }
 
 // Log is used to dump all the steps in the Trace
@@ -65,12 +88,23 @@ func (t *Trace) logWithStepThreshold(stepThreshold time.Duration) {
 	endTime := time.Now()
 
 	totalTime := endTime.Sub(t.startTime)
-	buffer.WriteString(fmt.Sprintf("Trace[%d]: %q (started: %v) (total time: %v):\n", tracenum, t.name, t.startTime, totalTime))
+	buffer.WriteString(fmt.Sprintf("Trace[%d]: %q ", tracenum, t.name))
+	if len(t.fields) > 0 {
+		writeFields(&buffer, t.fields)
+		buffer.WriteString(" ")
+	}
+	buffer.WriteString(fmt.Sprintf("(started: %v) (total time: %v):\n", t.startTime, totalTime))
 	lastStepTime := t.startTime
 	for _, step := range t.steps {
 		stepDuration := step.stepTime.Sub(lastStepTime)
 		if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4) {
-			buffer.WriteString(fmt.Sprintf("Trace[%d]: [%v] [%v] %v\n", tracenum, step.stepTime.Sub(t.startTime), stepDuration, step.msg))
+			buffer.WriteString(fmt.Sprintf("Trace[%d]: [%v] [%v] ", tracenum, step.stepTime.Sub(t.startTime), stepDuration))
+			buffer.WriteString(step.msg)
+			if len(step.fields) > 0 {
+				buffer.WriteString(" ")
+				writeFields(&buffer, step.fields)
+			}
+			buffer.WriteString("\n")
 		}
 		lastStepTime = step.stepTime
 	}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -37,7 +37,7 @@ func TestStep(t *testing.T) {
 			inputString: "",
 			expectedTrace: &Trace{
 				steps: []traceStep{
-					{time.Now(), ""},
+					{stepTime: time.Now(), msg: ""},
 				},
 			},
 		},
@@ -46,7 +46,7 @@ func TestStep(t *testing.T) {
 			inputString: "test2",
 			expectedTrace: &Trace{
 				steps: []traceStep{
-					{time.Now(), "test2"},
+					{stepTime: time.Now(), msg: "test2"},
 				},
 			},
 		},
@@ -83,35 +83,69 @@ func TestTotalTime(t *testing.T) {
 }
 
 func TestLog(t *testing.T) {
-	test := struct {
+	tests := []struct {
 		name             string
+		msg              string
+		fields           []Field
 		expectedMessages []string
 		sampleTrace      *Trace
 	}{
-		name: "Check the log dump with 3 msg",
-		expectedMessages: []string{
-			"msg1", "msg2", "msg3",
-		},
-		sampleTrace: &Trace{
-			name: "Sample Trace",
-			steps: []traceStep{
-				{time.Now(), "msg1"},
-				{time.Now(), "msg2"},
-				{time.Now(), "msg3"},
+		{
+			name: "Check the log dump with 3 msg",
+			expectedMessages: []string{
+				"msg1", "msg2", "msg3",
 			},
+			sampleTrace: &Trace{
+				name: "Sample Trace",
+				steps: []traceStep{
+					{stepTime: time.Now(), msg: "msg1"},
+					{stepTime: time.Now(), msg: "msg2"},
+					{stepTime: time.Now(), msg: "msg3"},
+				},
+			},
+		},
+		{
+			name: "Check formatting",
+			expectedMessages: []string{
+				"URL:/api,count:3", "msg1 str:text,int:2,bool:false", "msg2 x:1",
+			},
+			sampleTrace: &Trace{
+				name:   "Sample Trace",
+				fields: []Field{{"URL", "/api"}, {"count", 3}},
+				steps: []traceStep{
+					{stepTime: time.Now(), msg: "msg1", fields: []Field{{"str", "text"}, {"int", 2}, {"bool", false}}},
+					{stepTime: time.Now(), msg: "msg2", fields: []Field{{"x", "1"}}},
+				},
+			},
+		},
+		{
+			name: "Check fixture formatted",
+			expectedMessages: []string{
+				"URL:/api,count:3", "msg1 str:text,int:2,bool:false", "msg2 x:1",
+			},
+			sampleTrace: fieldsTraceFixture(),
 		},
 	}
 
-	t.Run(test.name, func(t *testing.T) {
-		var buf bytes.Buffer
-		klog.SetOutput(&buf)
-		test.sampleTrace.Log()
-		for _, msg := range test.expectedMessages {
-			if !strings.Contains(buf.String(), msg) {
-				t.Errorf("\nMsg %q not found in log: \n%v\n", msg, buf.String())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			klog.SetOutput(&buf)
+			test.sampleTrace.Log()
+			for _, msg := range test.expectedMessages {
+				if !strings.Contains(buf.String(), msg) {
+					t.Errorf("\nMsg %q not found in log: \n%v\n", msg, buf.String())
+				}
 			}
-		}
-	})
+		})
+	}
+}
+
+func fieldsTraceFixture() *Trace {
+	trace := New("Sample Trace", Field{"URL", "/api"}, Field{"count", 3})
+	trace.Step("msg1", Field{"str", "text"}, Field{"int", 2}, Field{"bool", false})
+	trace.Step("msg2", Field{"x", "1"})
+	return trace
 }
 
 func TestLogIfLong(t *testing.T) {


### PR DESCRIPTION
It's common pattern in k8s to create a trace like so:

```
trace := utiltrace.New("Get " + req.URL.Path)
```

Or

```
trace := utiltrace.New(fmt.Sprintf("GuaranteedUpdate etcd3: %s", getTypeName(out)))
```

Or

```
trace.Step(fmt.Sprintf("Writing http response done (%d items)", meta.LenList(result)))
```

Which results in string concatenation even if the trace is never logged.

This adds optional field args to both `New` and `Step`:

```
trace.New("Get", trace.Field{"URL", req.URL.Path}, trace.Field{"Accepts", req.Header.Accepts})
```

Or

```
trace.Step("Writing http response done", trace.Field{"item-count", meta.LenList(result)})
```

cc @liggitt @roycaihw @sttts 