### PR TITLE
Changing AtoI to uParseInt to handle overflow problems.

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -17,6 +17,7 @@ limitations under the License.
 package net
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -136,10 +137,13 @@ func IsIPv6CIDR(cidr *net.IPNet) bool {
 
 // ParsePort parses a string representing an IP port.  If the string is not a
 // valid port number, this returns an error.
-func ParsePort(port string) (int, error) {
+func ParsePort(port string, allowZero bool) (int, error) {
 	portInt, err := strconv.ParseUint(port, 10, 16)
 	if err != nil {
 		return 0, err
+	}
+	if int(portInt) == 0 && !allowZero {
+		errors.New("Port 0 is not allowed, provide non 0 port or make allowZero true")
 	}
 	return int(portInt), nil
 }

--- a/net/net.go
+++ b/net/net.go
@@ -137,12 +137,9 @@ func IsIPv6CIDR(cidr *net.IPNet) bool {
 // ParsePort parses a string representing an IP port.  If the string is not a
 // valid port number, this returns an error.
 func ParsePort(port string) (int, error) {
-	portInt, err := strconv.Atoi(port)
+	portInt, err := strconv.ParseUint(port, 10, 16)
 	if err != nil {
 		return 0, err
 	}
-	if !(0 < portInt && portInt <= 65535) {
-		return 0, fmt.Errorf("%d is not a valid port: must be between 1 and 65535, inclusive", portInt)
-	}
-	return portInt, nil
+	return int(portInt), nil
 }

--- a/net/net.go
+++ b/net/net.go
@@ -142,8 +142,8 @@ func ParsePort(port string, allowZero bool) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if int(portInt) == 0 && !allowZero {
-		errors.New("Port 0 is not allowed, provide non 0 port or make allowZero true")
+	if portInt == 0 && !allowZero {
+		return 0, errors.New("0 is not a valid port number")
 	}
 	return int(portInt), nil
 }

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -452,7 +452,7 @@ func TestParsePort(t *testing.T) {
 	var tests = []struct {
 		name          string
 		port          string
-		allowZero	  bool
+		allowZero     bool
 		expectedPort  int
 		expectedError bool
 	}{
@@ -475,7 +475,7 @@ func TestParsePort(t *testing.T) {
 			name:          "invalid port: not a number",
 			port:          "a",
 			expectedError: true,
-			allowZero: false,
+			allowZero:     false,
 		},
 		{
 			name:          "invalid port: too small",
@@ -493,10 +493,9 @@ func TestParsePort(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:          "zero port: allowed",
-			port:          "0",
-			allowZero:     true,
-			expectedError: false,
+			name:      "zero port: allowed",
+			port:      "0",
+			allowZero: true,
 		},
 		{
 			name:          "zero port: not allowed",
@@ -507,7 +506,7 @@ func TestParsePort(t *testing.T) {
 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			actualPort, actualError := ParsePort(rt.port, allowZero)
+			actualPort, actualError := ParsePort(rt.port, rt.allowZero)
 
 			if actualError != nil && !rt.expectedError {
 				t.Errorf("%s unexpected failure: %v", rt.name, actualError)

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -452,6 +452,7 @@ func TestParsePort(t *testing.T) {
 	var tests = []struct {
 		name          string
 		port          string
+		allowZero	  bool
 		expectedPort  int
 		expectedError bool
 	}{
@@ -474,6 +475,7 @@ func TestParsePort(t *testing.T) {
 			name:          "invalid port: not a number",
 			port:          "a",
 			expectedError: true,
+			allowZero: false,
 		},
 		{
 			name:          "invalid port: too small",
@@ -490,11 +492,22 @@ func TestParsePort(t *testing.T) {
 			port:          "65536",
 			expectedError: true,
 		},
+		{
+			name:          "zero port: allowed",
+			port:          "0",
+			allowZero:     true,
+			expectedError: false,
+		},
+		{
+			name:          "zero port: not allowed",
+			port:          "0",
+			expectedError: true,
+		},
 	}
 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			actualPort, actualError := ParsePort(rt.port)
+			actualPort, actualError := ParsePort(rt.port, allowZero)
 
 			if actualError != nil && !rt.expectedError {
 				t.Errorf("%s unexpected failure: %v", rt.name, actualError)


### PR DESCRIPTION
Changing AtoI to uParseInt to handle overflow problems with 16 bit integers. Also removing the check for port range because uParseInt provides us with that now.