### PR TITLE
Fix incorrect handling of klog.Verbose

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.3.0
-	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.0.0
 )
+
+replace k8s.io/klog/v2 => k8s.io/klog/v2 v2.0.0-20190919134220-6084f89080e3

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.3.0
-	k8s.io/klog v0.3.0
+	k8s.io/klog v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
+github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
@@ -10,5 +12,5 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-k8s.io/klog v0.3.0 h1:0VPpR+sizsiivjIfIAQH/rl8tan6jvWkS7lU+0di3lE=
-k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
+k8s.io/klog/v2 v2.0.0-20190919134220-6084f89080e3 h1:t3dij3nV3U/8i+4qs40h5LZUuLCJSHEEkB1YXffcZ5c=
+k8s.io/klog/v2 v2.0.0-20190919134220-6084f89080e3/go.mod h1:q4PVo0BneA7GsUJvFqoEvOCVmYJP0c5Y4VxrAYpJrIk=

--- a/nsenter/nsenter.go
+++ b/nsenter/nsenter.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/exec"
 )
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -22,7 +22,7 @@ import (
 	"math/rand"
 	"time"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // Field is a key value pair that provides additional details about the trace.
@@ -97,7 +97,7 @@ func (t *Trace) logWithStepThreshold(stepThreshold time.Duration) {
 	lastStepTime := t.startTime
 	for _, step := range t.steps {
 		stepDuration := step.stepTime.Sub(lastStepTime)
-		if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4) {
+		if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4).Enabled() {
 			buffer.WriteString(fmt.Sprintf("Trace[%d]: [%v] [%v] ", tracenum, step.stepTime.Sub(t.startTime), stepDuration))
 			buffer.WriteString(step.msg)
 			if len(step.fields) > 0 {
@@ -109,7 +109,7 @@ func (t *Trace) logWithStepThreshold(stepThreshold time.Duration) {
 		lastStepTime = step.stepTime
 	}
 	stepDuration := endTime.Sub(lastStepTime)
-	if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4) {
+	if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4).Enabled() {
 		buffer.WriteString(fmt.Sprintf("Trace[%d]: [%v] [%v] END\n", tracenum, endTime.Sub(t.startTime), stepDuration))
 	}
 

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func TestStep(t *testing.T) {


### PR DESCRIPTION
klog.V() is now returning klog.Verbose instead of bool,
so calls to klog.V() need to update to klog.V(...).Enabled()

Signed-off-by: Miguel Herranz <miguel@midokura.com>