### PR TITLE
feature: implement Output method for FakeCmd

### DIFF
--- a/mount/safe_format_and_mount_test.go
+++ b/mount/safe_format_and_mount_test.go
@@ -240,9 +240,9 @@ func makeFakeCmd(fakeCmd *testingexec.FakeCmd, cmd string, args ...string) testi
 	}
 }
 
-func makeFakeOutput(output string, err error) testingexec.FakeCombinedOutputAction {
+func makeFakeOutput(output string, err error) testingexec.FakeAction {
 	o := output
-	return func() ([]byte, error) {
-		return []byte(o), err
+	return func() ([]byte, []byte, error) {
+		return []byte(o), nil, err
 	}
 }


### PR DESCRIPTION
`Output` method is useful in some scenarios, and this PR implements it.
Ref: kubernetes/kubeadm#1925