### PR TITLE
Split MajorMinor into two fields

### DIFF
--- a/mount/mount_helper_unix.go
+++ b/mount/mount_helper_unix.go
@@ -61,8 +61,12 @@ type MountInfo struct {
 	ID int
 	// The ID of the parent mount (or of self for the root of this mount namespace's mount tree).
 	ParentID int
-	// The value of `st_dev` for files on this filesystem.
-	MajorMinor string
+	// Major indicates one half of the device ID which identifies the device class
+	// (parsed from `st_dev` for files on this filesystem).
+	Major int
+	// Minor indicates one half of the device ID which identifies a specific
+	// instance of device (parsed from `st_dev` for files on this filesystem).
+	Minor int
 	// The pathname of the directory in the filesystem which forms the root of this mount.
 	Root string
 	// Mount source, filesystem-specific information. e.g. device, tmpfs name.
@@ -106,10 +110,24 @@ func ParseMountInfo(filename string) ([]MountInfo, error) {
 		if err != nil {
 			return nil, err
 		}
+		mm := strings.Split(fields[2], ":")
+		if len(mm) != 2 {
+			return nil, fmt.Errorf("parsing '%s' failed: unexpected minor:major pair %s", line, mm)
+		}
+		major, err := strconv.Atoi(mm[0])
+		if err != nil {
+			return nil, fmt.Errorf("parsing '%s' failed: unable to parse major device id, err:%v", mm[0], err)
+		}
+		minor, err := strconv.Atoi(mm[1])
+		if err != nil {
+			return nil, fmt.Errorf("parsing '%s' failed: unable to parse minor device id, err:%v", mm[1], err)
+		}
+
 		info := MountInfo{
 			ID:           id,
 			ParentID:     parentID,
-			MajorMinor:   fields[2],
+			Major:        major,
+			Minor:        minor,
 			Root:         fields[3],
 			MountPoint:   fields[4],
 			MountOptions: strings.Split(fields[5], ","),

--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -499,7 +499,8 @@ func SearchMountPoints(hostSource, mountInfoPath string) ([]string, error) {
 
 	mountID := 0
 	rootPath := ""
-	majorMinor := ""
+	major := -1
+	minor := -1
 
 	// Finding the underlying root path and major:minor if possible.
 	// We need search in backward order because it's possible for later mounts
@@ -509,12 +510,13 @@ func SearchMountPoints(hostSource, mountInfoPath string) ([]string, error) {
 			// If it's a mount point or path under a mount point.
 			mountID = mis[i].ID
 			rootPath = filepath.Join(mis[i].Root, strings.TrimPrefix(hostSource, mis[i].MountPoint))
-			majorMinor = mis[i].MajorMinor
+			major = mis[i].Major
+			minor = mis[i].Minor
 			break
 		}
 	}
 
-	if rootPath == "" || majorMinor == "" {
+	if rootPath == "" || major == -1 || minor == -1 {
 		return nil, fmt.Errorf("failed to get root path and major:minor for %s", hostSource)
 	}
 
@@ -524,7 +526,7 @@ func SearchMountPoints(hostSource, mountInfoPath string) ([]string, error) {
 			// Ignore mount entry for mount source itself.
 			continue
 		}
-		if mis[i].Root == rootPath && mis[i].MajorMinor == majorMinor {
+		if mis[i].Root == rootPath && mis[i].Major == major && mis[i].Minor == minor {
 			refs = append(refs, mis[i].MountPoint)
 		}
 	}


### PR DESCRIPTION
this reflects what is in the docker/docker/pkg/mount API. makes it
easier to port additional code to out API.