### PR TITLE
Import LocalPort from pkg/proxy and add IP family to LocalPort

### DIFF
--- a/net/port.go
+++ b/net/port.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/net/port.go
+++ b/net/port.go
@@ -98,8 +98,10 @@ type PortOpener interface {
 	OpenLocalPort(lp *LocalPort) (Closeable, error)
 }
 
-// listenPortOpener opens ports by calling bind() and listen().
 type listenPortOpener struct{}
+
+// ListenPortOpener opens ports by calling bind() and listen().
+var ListenPortOpener listenPortOpener
 
 // OpenLocalPort holds the given local port open.
 func (l *listenPortOpener) OpenLocalPort(lp *LocalPort) (Closeable, error) {

--- a/net/port.go
+++ b/net/port.go
@@ -22,19 +22,19 @@ import (
 	"strconv"
 )
 
-// IPFamily refers to a specific family if not empty, i.e. "4" or "6"
+// IPFamily refers to a specific family if not empty, i.e. "4" or "6".
 type IPFamily string
 
-// Constants refering to IPv4 and IPv6
+// Constants for valid IPFamilys:
 const (
 	IPv4 IPFamily = "4"
 	IPv6          = "6"
 )
 
-// Protocol is a network protocol support by LocalPort
+// Protocol is a network protocol support by LocalPort.
 type Protocol string
 
-// Constants refering to TCP and UDP
+// Constants for valid protocols:
 const (
 	TCP Protocol = "tcp"
 	UDP Protocol = "udp"
@@ -44,24 +44,25 @@ const (
 // and potentially a specific IP family.
 // A LocalPort can be opened and subsequently closed.
 type LocalPort struct {
-	// Description is an arbitrary string
+	// Description is an arbitrary string.
 	Description string
 	// IP is the IP address part of a given local port.
 	// If this string is empty, the port binds to all local IP addresses.
 	IP string
-	// If IPFamily is not empty, the port binds only to addresses of this family
-	// IF empty along with IP, bind to local addresses of any family
+	// If IPFamily is not empty, the port binds only to addresses of this
+	// family.
+	// IF empty along with IP, bind to local addresses of any family.
 	IPFamily IPFamily
-	// Port is the port number
-	// A value of 0 causes a port to be automatically chosen
+	// Port is the port number.
+	// A value of 0 causes a port to be automatically chosen.
 	Port int
-	// Protocol is the protocol, "tcp" or "udp"
-	// The value is assumed to be lower-case
+	// Protocol is the protocol, "tcp" or "udp".
+	// The value is assumed to be lower-case.
 	Protocol Protocol
 }
 
 // NewLocalPort returns a LocalPort instance and ensures IPFamily and IP are
-// consistent and that the given protocol is valid
+// consistent and that the given protocol is valid.
 func NewLocalPort(desc, ip string, ipFamily IPFamily, port int, protocol Protocol) (*LocalPort, error) {
 	if protocol != TCP && protocol != UDP {
 		return nil, fmt.Errorf("Unsupported protocol %s", protocol)
@@ -87,13 +88,12 @@ func (lp *LocalPort) String() string {
 	return fmt.Sprintf("%q (%s/%s%s)", lp.Description, ipPort, lp.Protocol, lp.IPFamily)
 }
 
-// Closeable closes an opened LocalPort
+// Closeable closes an opened LocalPort.
 type Closeable interface {
 	Close() error
 }
 
-// PortOpener can open a LocalPort and allows later closing it
-// Abstracted out for testing.
+// PortOpener can open a LocalPort and allows later closing it.
 type PortOpener interface {
 	OpenLocalPort(lp *LocalPort) (Closeable, error)
 }

--- a/net/port.go
+++ b/net/port.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"k8s.io/klog"
+)
+
+// LocalPort describes a port on specific IP address and protocol
+type LocalPort struct {
+	// Description is the identity message of a given local port.
+	Description string
+	// IP is the IP address part of a given local port.
+	// If this string is empty, the port binds to all local IP addresses.
+	IP string
+	// Port is the port part of a given local port.
+	Port int
+	// Protocol is the protocol part of a given local port.
+	// The value is assumed to be lower-case. For example, "udp" not "UDP", "tcp" not "TCP".
+	Protocol string
+}
+
+func (lp *LocalPort) String() string {
+	ipPort := net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port))
+	return fmt.Sprintf("%q (%s/%s)", lp.Description, ipPort, lp.Protocol)
+}
+
+// Closeable is an interface around closing a port.
+type Closeable interface {
+	Close() error
+}
+
+// PortOpener is an interface around port opening/closing.
+// Abstracted out for testing.
+type PortOpener interface {
+	OpenLocalPort(lp *LocalPort) (Closeable, error)
+}
+
+// listenPortOpener opens ports by calling bind() and listen().
+type listenPortOpener struct{}
+
+// OpenLocalPort holds the given local port open.
+func (l *listenPortOpener) OpenLocalPort(lp *LocalPort) (Closeable, error) {
+	return openLocalPort(lp)
+}
+
+func openLocalPort(lp *LocalPort) (Closeable, error) {
+	// For ports on node IPs, open the actual port and hold it, even though we
+	// use ipvs or iptables to redirect traffic.
+	// This ensures a) that it's safe to use that port and b) that (a) stays
+	// true.  The risk is that some process on the node (e.g. sshd or kubelet)
+	// is using a port and we give that same port out to a Service.  That would
+	// be bad because ipvs or iptables would silently claim the traffic
+	// but the process would never know.
+	// NOTE: We should not need to have a real listen()ing socket - bind()
+	// should be enough, but I can't figure out a way to e2e test without
+	// it.  Tools like 'ss' and 'netstat' do not show sockets that are
+	// bind()ed but not listen()ed, and at least the default debian netcat
+	// has no way to avoid about 10 seconds of retries.
+	var socket Closeable
+	switch lp.Protocol {
+	case "tcp":
+		listener, err := net.Listen("tcp", net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port)))
+		if err != nil {
+			return nil, err
+		}
+		socket = listener
+	case "udp":
+		addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port)))
+		if err != nil {
+			return nil, err
+		}
+		conn, err := net.ListenUDP("udp", addr)
+		if err != nil {
+			return nil, err
+		}
+		socket = conn
+	default:
+		return nil, fmt.Errorf("unknown protocol %q", lp.Protocol)
+	}
+	klog.V(2).Infof("Opened local port %s", lp.String())
+	return socket, nil
+}

--- a/net/port.go
+++ b/net/port.go
@@ -31,23 +31,28 @@ const (
 	IPv6          = "6"
 )
 
-// LocalPort describes a port on specific IP address and protocol
+// LocalPort represents an IP address and port pair along with a protocol
+// and potentially a specific IP family.
+// A LocalPort can be opened and subsequently closed.
 type LocalPort struct {
-	// Description is the identity message of a given local port.
+	// Description is an arbitrary string
 	Description string
 	// IP is the IP address part of a given local port.
 	// If this string is empty, the port binds to all local IP addresses.
 	IP string
 	// If IPFamily is not empty, the port binds only to addresses of this family
+	// IF empty along with IP, bind to local addresses of any family
 	IPFamily IPFamily
-	// Port is the port part of a given local port.
+	// Port is the port number
+	// A value of 0 causes a port to be automatically chosen
 	Port int
-	// Protocol is the protocol part of a given local port.
-	// The value is assumed to be lower-case. For example, "udp" not "UDP", "tcp" not "TCP".
+	// Protocol is the protocol, "tcp" or "udp"
+	// The value is assumed to be lower-case
 	Protocol string
 }
 
-// NewLocalPort creates a new LocalPort struct
+// NewLocalPort returns a LocalPort instance and ensures IPFamily and IP are
+// consistent and that the given protocol is valid
 func NewLocalPort(desc, ip string, ipFamily IPFamily, port int, protocol string) (*LocalPort, error) {
 	if protocol != "tcp" && protocol != "sctp" && protocol != "udp" {
 		return nil, fmt.Errorf("Unsupported protocol %s", protocol)
@@ -73,12 +78,12 @@ func (lp *LocalPort) String() string {
 	return fmt.Sprintf("%q (%s/%s%s)", lp.Description, ipPort, lp.Protocol, lp.IPFamily)
 }
 
-// Closeable is an interface around closing a port.
+// Closeable closes an opened LocalPort
 type Closeable interface {
 	Close() error
 }
 
-// PortOpener is an interface around port opening/closing.
+// PortOpener can open a LocalPort and allows later closing it
 // Abstracted out for testing.
 type PortOpener interface {
 	OpenLocalPort(lp *LocalPort) (Closeable, error)

--- a/net/port.go
+++ b/net/port.go
@@ -49,6 +49,27 @@ type LocalPort struct {
 	Protocol string
 }
 
+// NewLocalPort creates a new LocalPort struct
+func NewLocalPort(desc, ip string, ipFamily IPFamily, port int, protocol string) (*LocalPort, error) {
+	if protocol != "tcp" && protocol != "sctp" && protocol != "udp" {
+		return nil, fmt.Errorf("Unsupported protocol %s", protocol)
+	}
+	if ipFamily != "" && ipFamily != "4" && ipFamily != "6" {
+		return nil, fmt.Errorf("Invalid IP family %s", ipFamily)
+	}
+	if ip != "" {
+		parsedIP := net.ParseIP(ip)
+		if parsedIP == nil {
+			return nil, fmt.Errorf("invalid ip address %s", ip)
+		}
+		asIPv4 := parsedIP.To4()
+		if asIPv4 == nil && ipFamily == IPv4 || asIPv4 != nil && ipFamily == IPv6 {
+			return nil, fmt.Errorf("ip address and family mismatch %s, %s", ip, ipFamily)
+		}
+	}
+	return &LocalPort{Description: desc, IP: ip, IPFamily: ipFamily, Port: port, Protocol: protocol}, nil
+}
+
 func (lp *LocalPort) String() string {
 	ipPort := net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port))
 	return fmt.Sprintf("%q (%s/%s%s)", lp.Description, ipPort, lp.Protocol, lp.IPFamily)

--- a/net/port.go
+++ b/net/port.go
@@ -94,6 +94,11 @@ func openLocalPort(lp *LocalPort) (Closeable, error) {
 			return nil, err
 		}
 		socket = conn
+	case "sctp":
+		// SCTP ports are intentionally ignored, to ensure we don't cause the sctp
+		// kernel module to be loaded, which breaks userspace SCTP support (and
+		// may be considered a security risk by some administrators).
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unknown protocol %q", lp.Protocol)
 	}

--- a/net/port.go
+++ b/net/port.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-
-	"k8s.io/klog"
 )
 
 // IPFamily refers to a specific family if not empty, i.e. "4" or "6"
@@ -123,6 +121,5 @@ func openLocalPort(lp *LocalPort) (Closeable, error) {
 	default:
 		return nil, fmt.Errorf("unknown protocol %q", lp.Protocol)
 	}
-	klog.V(2).Infof("Opened local port %s", lp.String())
 	return socket, nil
 }

--- a/net/port.go
+++ b/net/port.go
@@ -74,18 +74,6 @@ func (l *listenPortOpener) OpenLocalPort(lp *LocalPort) (Closeable, error) {
 }
 
 func openLocalPort(lp *LocalPort) (Closeable, error) {
-	// For ports on node IPs, open the actual port and hold it, even though we
-	// use ipvs or iptables to redirect traffic.
-	// This ensures a) that it's safe to use that port and b) that (a) stays
-	// true.  The risk is that some process on the node (e.g. sshd or kubelet)
-	// is using a port and we give that same port out to a Service.  That would
-	// be bad because ipvs or iptables would silently claim the traffic
-	// but the process would never know.
-	// NOTE: We should not need to have a real listen()ing socket - bind()
-	// should be enough, but I can't figure out a way to e2e test without
-	// it.  Tools like 'ss' and 'netstat' do not show sockets that are
-	// bind()ed but not listen()ed, and at least the default debian netcat
-	// has no way to avoid about 10 seconds of retries.
 	var socket Closeable
 	network := lp.Protocol + string(lp.IPFamily)
 	hostPort := net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port))

--- a/net/port_test.go
+++ b/net/port_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/net/port_test.go
+++ b/net/port_test.go
@@ -16,7 +16,27 @@ limitations under the License.
 
 package net
 
-import "testing"
+import (
+	"testing"
+)
+
+func ExampleLocalPort() {
+	lp, err := NewLocalPort(
+		"TCP port",
+		"",
+		IPv4,
+		443,
+		TCP,
+	)
+	if err != nil {
+		panic(err)
+	}
+	port, err := ListenPortOpener.OpenLocalPort(lp)
+	if err != nil {
+		panic(err)
+	}
+	port.Close()
+}
 
 func TestLocalPortString(t *testing.T) {
 	testCases := []struct {

--- a/net/port_test.go
+++ b/net/port_test.go
@@ -28,14 +28,14 @@ func TestLocalPortString(t *testing.T) {
 		expectedStr string
 		expectedErr bool
 	}{
-		{"IPv4 UDP", "1.2.3.4", "", 9999, "udp", "\"IPv4 UDP\" (1.2.3.4:9999/udp)", false},
-		{"IPv4 TCP", "5.6.7.8", "", 1053, "tcp", "\"IPv4 TCP\" (5.6.7.8:1053/tcp)", false},
-		{"IPv6 TCP", "2001:db8::1", "", 80, "tcp", "\"IPv6 TCP\" ([2001:db8::1]:80/tcp)", false},
-		{"IPv4 SCTP", "9.10.11.12", "", 7777, "sctp", "\"IPv4 SCTP\" (9.10.11.12:7777/sctp)", false},
-		{"IPv6 SCTP", "2001:db8::2", "", 80, "sctp", "\"IPv6 SCTP\" ([2001:db8::2]:80/sctp)", false},
-		{"IPv4 TCP, all addresses", "", IPv4, 1053, "tcp", "\"IPv4 TCP, all addresses\" (:1053/tcp4)", false},
-		{"IPv6 TCP, all addresses", "", IPv6, 80, "tcp", "\"IPv6 TCP, all addresses\" (:80/tcp6)", false},
-		{"No ip family TCP, all addresses", "", "", 80, "tcp", "\"No ip family TCP, all addresses\" (:80/tcp)", false},
+		{"IPv4 UDP", "1.2.3.4", "", 9999, "udp", `"IPv4 UDP" (1.2.3.4:9999/udp)`, false},
+		{"IPv4 TCP", "5.6.7.8", "", 1053, "tcp", `"IPv4 TCP" (5.6.7.8:1053/tcp)`, false},
+		{"IPv6 TCP", "2001:db8::1", "", 80, "tcp", `"IPv6 TCP" ([2001:db8::1]:80/tcp)`, false},
+		{"IPv4 SCTP", "9.10.11.12", "", 7777, "sctp", `"IPv4 SCTP" (9.10.11.12:7777/sctp)`, false},
+		{"IPv6 SCTP", "2001:db8::2", "", 80, "sctp", `"IPv6 SCTP" ([2001:db8::2]:80/sctp)`, false},
+		{"IPv4 TCP, all addresses", "", IPv4, 1053, "tcp", `"IPv4 TCP, all addresses" (:1053/tcp4)`, false},
+		{"IPv6 TCP, all addresses", "", IPv6, 80, "tcp", `"IPv6 TCP, all addresses" (:80/tcp6)`, false},
+		{"No ip family TCP, all addresses", "", "", 80, "tcp", `"No ip family TCP, all addresses" (:80/tcp)`, false},
 		{"IP family mismatch", "2001:db8::2", IPv4, 80, "sctp", "", true},
 		{"IP family mismatch", "1.2.3.4", IPv6, 80, "sctp", "", true},
 		{"Unsupported protocol", "2001:db8::2", "", 80, "http", "", true},

--- a/net/port_test.go
+++ b/net/port_test.go
@@ -26,24 +26,40 @@ func TestLocalPortString(t *testing.T) {
 		port        int
 		protocol    string
 		expectedStr string
+		expectedErr bool
 	}{
-		{"IPv4 UDP", "1.2.3.4", "", 9999, "udp", "\"IPv4 UDP\" (1.2.3.4:9999/udp)"},
-		{"IPv4 TCP", "5.6.7.8", "", 1053, "tcp", "\"IPv4 TCP\" (5.6.7.8:1053/tcp)"},
-		{"IPv6 TCP", "2001:db8::1", "", 80, "tcp", "\"IPv6 TCP\" ([2001:db8::1]:80/tcp)"},
-		{"IPv4 SCTP", "9.10.11.12", "", 7777, "sctp", "\"IPv4 SCTP\" (9.10.11.12:7777/sctp)"},
-		{"IPv6 SCTP", "2001:db8::2", "", 80, "sctp", "\"IPv6 SCTP\" ([2001:db8::2]:80/sctp)"},
-		{"IPv4 TCP, all addresses", "", IPv4, 1053, "tcp", "\"IPv4 TCP, all addresses\" (:1053/tcp4)"},
-		{"IPv6 TCP, all addresses", "", IPv6, 80, "tcp", "\"IPv6 TCP, all addresses\" (:80/tcp6)"},
-		{"No ip family TCP, all addresses", "", "", 80, "tcp", "\"No ip family TCP, all addresses\" (:80/tcp)"},
+		{"IPv4 UDP", "1.2.3.4", "", 9999, "udp", "\"IPv4 UDP\" (1.2.3.4:9999/udp)", false},
+		{"IPv4 TCP", "5.6.7.8", "", 1053, "tcp", "\"IPv4 TCP\" (5.6.7.8:1053/tcp)", false},
+		{"IPv6 TCP", "2001:db8::1", "", 80, "tcp", "\"IPv6 TCP\" ([2001:db8::1]:80/tcp)", false},
+		{"IPv4 SCTP", "9.10.11.12", "", 7777, "sctp", "\"IPv4 SCTP\" (9.10.11.12:7777/sctp)", false},
+		{"IPv6 SCTP", "2001:db8::2", "", 80, "sctp", "\"IPv6 SCTP\" ([2001:db8::2]:80/sctp)", false},
+		{"IPv4 TCP, all addresses", "", IPv4, 1053, "tcp", "\"IPv4 TCP, all addresses\" (:1053/tcp4)", false},
+		{"IPv6 TCP, all addresses", "", IPv6, 80, "tcp", "\"IPv6 TCP, all addresses\" (:80/tcp6)", false},
+		{"No ip family TCP, all addresses", "", "", 80, "tcp", "\"No ip family TCP, all addresses\" (:80/tcp)", false},
+		{"IP family mismatch", "2001:db8::2", IPv4, 80, "sctp", "", true},
+		{"IP family mismatch", "1.2.3.4", IPv6, 80, "sctp", "", true},
+		{"Unsupported protocol", "2001:db8::2", "", 80, "http", "", true},
+		{"Invalid IP", "300", "", 80, "tcp", "", true},
+		{"Invalid ip family", "", "5", 80, "tcp", "", true},
 	}
 
 	for _, tc := range testCases {
-		lp := &LocalPort{
-			Description: tc.description,
-			IP:          tc.ip,
-			IPFamily:    tc.family,
-			Port:        tc.port,
-			Protocol:    tc.protocol,
+		lp, err := NewLocalPort(
+			tc.description,
+			tc.ip,
+			tc.family,
+			tc.port,
+			tc.protocol,
+		)
+		if tc.expectedErr {
+			if err == nil {
+				t.Errorf("Expected err when creating LocalPort %v", tc)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Unexpected err when creating LocalPort %s", err)
+			continue
 		}
 		str := lp.String()
 		if str != tc.expectedStr {

--- a/net/port_test.go
+++ b/net/port_test.go
@@ -22,21 +22,24 @@ func TestLocalPortString(t *testing.T) {
 	testCases := []struct {
 		description string
 		ip          string
+		family      IPFamily
 		port        int
 		protocol    string
 		expectedStr string
 	}{
-		{"IPv4 UDP", "1.2.3.4", 9999, "udp", "\"IPv4 UDP\" (1.2.3.4:9999/udp)"},
-		{"IPv4 TCP", "5.6.7.8", 1053, "tcp", "\"IPv4 TCP\" (5.6.7.8:1053/tcp)"},
-		{"IPv6 TCP", "2001:db8::1", 80, "tcp", "\"IPv6 TCP\" ([2001:db8::1]:80/tcp)"},
-		{"IPv4 SCTP", "9.10.11.12", 7777, "sctp", "\"IPv4 SCTP\" (9.10.11.12:7777/sctp)"},
-		{"IPv6 SCTP", "2001:db8::2", 80, "sctp", "\"IPv6 SCTP\" ([2001:db8::2]:80/sctp)"},
+		{"IPv4 UDP", "1.2.3.4", "", 9999, "udp", "\"IPv4 UDP\" (1.2.3.4:9999/udp)"},
+		{"IPv4 TCP", "5.6.7.8", "", 1053, "tcp", "\"IPv4 TCP\" (5.6.7.8:1053/tcp)"},
+		{"IPv4 TCP", "", IPv4, 1053, "tcp", "\"IPv4 TCP\" (:1053/tcp4)"},
+		{"IPv6 TCP", "2001:db8::1", "", 80, "tcp", "\"IPv6 TCP\" ([2001:db8::1]:80/tcp)"},
+		{"IPv4 SCTP", "9.10.11.12", "", 7777, "sctp", "\"IPv4 SCTP\" (9.10.11.12:7777/sctp)"},
+		{"IPv6 SCTP", "2001:db8::2", "", 80, "sctp", "\"IPv6 SCTP\" ([2001:db8::2]:80/sctp)"},
 	}
 
 	for _, tc := range testCases {
 		lp := &LocalPort{
 			Description: tc.description,
 			IP:          tc.ip,
+			IPFamily:    tc.family,
 			Port:        tc.port,
 			Protocol:    tc.protocol,
 		}

--- a/net/port_test.go
+++ b/net/port_test.go
@@ -24,23 +24,21 @@ func TestLocalPortString(t *testing.T) {
 		ip          string
 		family      IPFamily
 		port        int
-		protocol    string
+		protocol    Protocol
 		expectedStr string
 		expectedErr bool
 	}{
-		{"IPv4 UDP", "1.2.3.4", "", 9999, "udp", `"IPv4 UDP" (1.2.3.4:9999/udp)`, false},
-		{"IPv4 TCP", "5.6.7.8", "", 1053, "tcp", `"IPv4 TCP" (5.6.7.8:1053/tcp)`, false},
-		{"IPv6 TCP", "2001:db8::1", "", 80, "tcp", `"IPv6 TCP" ([2001:db8::1]:80/tcp)`, false},
-		{"IPv4 SCTP", "9.10.11.12", "", 7777, "sctp", `"IPv4 SCTP" (9.10.11.12:7777/sctp)`, false},
-		{"IPv6 SCTP", "2001:db8::2", "", 80, "sctp", `"IPv6 SCTP" ([2001:db8::2]:80/sctp)`, false},
-		{"IPv4 TCP, all addresses", "", IPv4, 1053, "tcp", `"IPv4 TCP, all addresses" (:1053/tcp4)`, false},
-		{"IPv6 TCP, all addresses", "", IPv6, 80, "tcp", `"IPv6 TCP, all addresses" (:80/tcp6)`, false},
-		{"No ip family TCP, all addresses", "", "", 80, "tcp", `"No ip family TCP, all addresses" (:80/tcp)`, false},
-		{"IP family mismatch", "2001:db8::2", IPv4, 80, "sctp", "", true},
-		{"IP family mismatch", "1.2.3.4", IPv6, 80, "sctp", "", true},
+		{"IPv4 UDP", "1.2.3.4", "", 9999, UDP, `"IPv4 UDP" (1.2.3.4:9999/udp)`, false},
+		{"IPv4 TCP", "5.6.7.8", "", 1053, TCP, `"IPv4 TCP" (5.6.7.8:1053/tcp)`, false},
+		{"IPv6 TCP", "2001:db8::1", "", 80, TCP, `"IPv6 TCP" ([2001:db8::1]:80/tcp)`, false},
+		{"IPv4 TCP, all addresses", "", IPv4, 1053, TCP, `"IPv4 TCP, all addresses" (:1053/tcp4)`, false},
+		{"IPv6 TCP, all addresses", "", IPv6, 80, TCP, `"IPv6 TCP, all addresses" (:80/tcp6)`, false},
+		{"No ip family TCP, all addresses", "", "", 80, TCP, `"No ip family TCP, all addresses" (:80/tcp)`, false},
+		{"IP family mismatch", "2001:db8::2", IPv4, 80, TCP, "", true},
+		{"IP family mismatch", "1.2.3.4", IPv6, 80, TCP, "", true},
 		{"Unsupported protocol", "2001:db8::2", "", 80, "http", "", true},
-		{"Invalid IP", "300", "", 80, "tcp", "", true},
-		{"Invalid ip family", "", "5", 80, "tcp", "", true},
+		{"Invalid IP", "300", "", 80, TCP, "", true},
+		{"Invalid ip family", "", "5", 80, TCP, "", true},
 	}
 
 	for _, tc := range testCases {

--- a/net/port_test.go
+++ b/net/port_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import "testing"
+
+func TestLocalPortString(t *testing.T) {
+	testCases := []struct {
+		description string
+		ip          string
+		port        int
+		protocol    string
+		expectedStr string
+	}{
+		{"IPv4 UDP", "1.2.3.4", 9999, "udp", "\"IPv4 UDP\" (1.2.3.4:9999/udp)"},
+		{"IPv4 TCP", "5.6.7.8", 1053, "tcp", "\"IPv4 TCP\" (5.6.7.8:1053/tcp)"},
+		{"IPv6 TCP", "2001:db8::1", 80, "tcp", "\"IPv6 TCP\" ([2001:db8::1]:80/tcp)"},
+		{"IPv4 SCTP", "9.10.11.12", 7777, "sctp", "\"IPv4 SCTP\" (9.10.11.12:7777/sctp)"},
+		{"IPv6 SCTP", "2001:db8::2", 80, "sctp", "\"IPv6 SCTP\" ([2001:db8::2]:80/sctp)"},
+	}
+
+	for _, tc := range testCases {
+		lp := &LocalPort{
+			Description: tc.description,
+			IP:          tc.ip,
+			Port:        tc.port,
+			Protocol:    tc.protocol,
+		}
+		str := lp.String()
+		if str != tc.expectedStr {
+			t.Errorf("Unexpected output for %s, expected: %s, got: %s", tc.description, tc.expectedStr, str)
+		}
+	}
+}

--- a/net/port_test.go
+++ b/net/port_test.go
@@ -29,10 +29,12 @@ func TestLocalPortString(t *testing.T) {
 	}{
 		{"IPv4 UDP", "1.2.3.4", "", 9999, "udp", "\"IPv4 UDP\" (1.2.3.4:9999/udp)"},
 		{"IPv4 TCP", "5.6.7.8", "", 1053, "tcp", "\"IPv4 TCP\" (5.6.7.8:1053/tcp)"},
-		{"IPv4 TCP", "", IPv4, 1053, "tcp", "\"IPv4 TCP\" (:1053/tcp4)"},
 		{"IPv6 TCP", "2001:db8::1", "", 80, "tcp", "\"IPv6 TCP\" ([2001:db8::1]:80/tcp)"},
 		{"IPv4 SCTP", "9.10.11.12", "", 7777, "sctp", "\"IPv4 SCTP\" (9.10.11.12:7777/sctp)"},
 		{"IPv6 SCTP", "2001:db8::2", "", 80, "sctp", "\"IPv6 SCTP\" ([2001:db8::2]:80/sctp)"},
+		{"IPv4 TCP, all addresses", "", IPv4, 1053, "tcp", "\"IPv4 TCP, all addresses\" (:1053/tcp4)"},
+		{"IPv6 TCP, all addresses", "", IPv6, 80, "tcp", "\"IPv6 TCP, all addresses\" (:80/tcp6)"},
+		{"No ip family TCP, all addresses", "", "", 80, "tcp", "\"No ip family TCP, all addresses\" (:80/tcp)"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Proposed in https://github.com/kubernetes/kubernetes/pull/87699#issuecomment-580725254

Obsoletes https://github.com/kubernetes/kubernetes/pull/80720

Would it be important to maintain the git history for `port.go`?