### PR TITLE
Adds nested traces to the trace library

### DIFF
--- a/trace/README.md
+++ b/trace/README.md
@@ -1,0 +1,67 @@
+# Trace
+
+This package provides an interface for recording the latency of operations and logging details
+about all operations where the latency exceeds a limit.
+
+## Usage
+
+To create a trace:
+
+```go
+func doSomething() {
+    opTrace := trace.New("operation", Field{Key: "fieldKey1", Value: "fieldValue1"})
+    defer opTrace.LogIfLong(100 * time.Millisecond)
+    // do something
+}
+```
+
+To split an trace into multiple steps:
+
+```go
+func doSomething() {
+    opTrace := trace.New("operation")
+    defer opTrace.LogIfLong(100 * time.Millisecond)
+    // do step 1
+    opTrace.Step("step1", Field{Key: "stepFieldKey1", Value: "stepFieldValue1"})
+    // do step 2
+    opTrace.Step("step2")
+}
+```
+
+To nest traces:
+
+```go
+func doSomething() {
+    rootTrace := trace.New("rootOperation")
+    defer rootTrace.LogIfLong(100 * time.Millisecond)
+    
+    func() {
+        nestedTrace := rootTrace.Nest("nested", Field{Key: "nestedFieldKey1", Value: "nestedFieldValue1"})
+        defer nestedTrace.LogIfLong(50 * time.Millisecond)
+        // do nested operation
+    }()
+}
+```
+
+Traces can also be logged unconditionally or introspected:
+
+```go
+opTrace.TotalTime() // Duration since the Trace was created
+opTrace.Log() // unconditionally log the trace
+```
+
+### Using context.Context to nest traces
+
+`context.Context` can be used to manage nested traces. Create traces by calling `trace.GetTraceFromContext(ctx).Nest`. 
+This is safe even if there is no parent trace already in the context because `(*(Trace)nil).Nest()` returns
+a top level trace.
+
+```go
+func doSomething(ctx context.Context) {
+    opTrace := trace.FromContext(ctx).Nest("operation") // create a trace, possibly nested
+    ctx = trace.ContextWithTrace(ctx, opTrace) // make this trace the parent trace of the context
+    defer opTrace.LogIfLong(50 * time.Millisecond)
+    
+    doSomethingElse(ctx)
+}
+```

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -32,13 +32,13 @@ type Field struct {
 	Value interface{}
 }
 
-type stepTraceTime interface {
+type stepTrace interface {
 	time() time.Time
 	writeStep(b *bytes.Buffer, formatter string, stepDuration time.Duration, lastStepTime time.Time) time.Time
 }
 
-func (t *Trace) sortStepTrace() []stepTraceTime {
-	var arr []stepTraceTime
+func (t *Trace) sortStepTrace() []stepTrace {
+	var arr []stepTrace
 
 	for _, step := range t.steps {
 		arr = append(arr, step)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -155,7 +155,7 @@ func (t *Trace) logWithStepThreshold(stepThreshold time.Duration) {
 	buffer.WriteString(fmt.Sprintf("(%v) (total time: %vms):", t.startTime.Format("02-Jan-2006 15:04:00.000"), totalTime.Milliseconds()))
 	lastStepTime := writeTrace(&buffer, t, fmt.Sprintf("\nTrace[%d]: ", tracenum), stepThreshold)
 	stepDuration := endTime.Sub(lastStepTime)
-	if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4).Enabled()  {
+	if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4).Enabled() {
 		buffer.WriteString(fmt.Sprintf("\nTrace[%d]: [%v] [%v] END\n", tracenum, endTime.Sub(t.startTime), stepDuration))
 	}
 
@@ -185,7 +185,7 @@ func (t *Trace) LogIfLong(threshold time.Duration) {
 	} else {
 		for _, s := range t.stepsTraces {
 			nestedTrace, ok := s.(*Trace)
-			if ok && nestedTrace.threshold != nil && time.Since(nestedTrace.startTime) >= *nestedTrace.threshold  {
+			if ok && nestedTrace.threshold != nil && time.Since(nestedTrace.startTime) >= *nestedTrace.threshold {
 				stepThreshold := calculateStepThreshold(nestedTrace)
 				nestedTrace.logWithStepThreshold(stepThreshold)
 			}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -208,7 +208,7 @@ func TestNestedTraceLog(t *testing.T) {
 				"Sample Trace", "msg1", "msg2", "msg3",
 			},
 			sampleTrace: &Trace{
-				name: "Sample Trace",
+				name:      "Sample Trace",
 				threshold: &thousandMs,
 				stepsTraces: []stepTrace{
 					&Trace{startTime: time.Now(), name: "msg1"},
@@ -223,7 +223,7 @@ func TestNestedTraceLog(t *testing.T) {
 				"Sample Trace", "msg1", "msg2", "msg3", "step1", "step2", "step3",
 			},
 			sampleTrace: &Trace{
-				name: "Sample Trace",
+				name:      "Sample Trace",
 				threshold: &thousandMs,
 				stepsTraces: []stepTrace{
 					&Trace{startTime: time.Now(), name: "msg1"},
@@ -241,7 +241,7 @@ func TestNestedTraceLog(t *testing.T) {
 				"Sample Trace", `"msg1" str:text,int:2,bool:false`,
 			},
 			sampleTrace: &Trace{
-				name: "Sample Trace",
+				name:      "Sample Trace",
 				threshold: &thousandMs,
 				stepsTraces: []stepTrace{
 					&Trace{startTime: time.Now(), name: "msg1", fields: []Field{{"str", "text"}, {"int", 2}, {"bool",
@@ -255,7 +255,7 @@ func TestNestedTraceLog(t *testing.T) {
 				"Sample Trace", "msg1", "nested1",
 			},
 			sampleTrace: &Trace{
-				name: "Sample Trace",
+				name:      "Sample Trace",
 				threshold: &thousandMs,
 				stepsTraces: []stepTrace{
 					&Trace{
@@ -380,9 +380,9 @@ func TestStepThreshold(t *testing.T) {
 	hundredMs := 100 * time.Millisecond
 	twoThousandMs := 1200 * time.Millisecond
 
-	tests := []struct{
-		name string
-		inputTrace *Trace
+	tests := []struct {
+		name              string
+		inputTrace        *Trace
 		expectedThreshold time.Duration
 	}{
 		{
@@ -390,36 +390,36 @@ func TestStepThreshold(t *testing.T) {
 			inputTrace: &Trace{
 				threshold: &thousandMs,
 				stepsTraces: []stepTrace{
-					traceStep{ msg: "trace 1"},
-					traceStep{ msg: "trace 2"},
-					&Trace{ threshold:&sixHundred },
-					&Trace{ name: "msg 1" },
+					traceStep{msg: "trace 1"},
+					traceStep{msg: "trace 2"},
+					&Trace{threshold: &sixHundred},
+					&Trace{name: "msg 1"},
 				},
 			},
-			expectedThreshold: 100*time.Millisecond,
+			expectedThreshold: 100 * time.Millisecond,
 		},
 		{
 			name: "Trace with  nested traces",
 			inputTrace: &Trace{
 				threshold: &thousandMs,
 				stepsTraces: []stepTrace{
-					traceStep{ msg: "trace 1"},
-					traceStep{ msg: "trace 2"},
-					&Trace{ threshold:&sixHundred },
-					&Trace{ name: "msg 1", threshold: &hundredMs},
+					traceStep{msg: "trace 1"},
+					traceStep{msg: "trace 2"},
+					&Trace{threshold: &sixHundred},
+					&Trace{name: "msg 1", threshold: &hundredMs},
 				},
 			},
-			expectedThreshold: 100*time.Millisecond,
+			expectedThreshold: 100 * time.Millisecond,
 		},
 		{
 			name: "Trace with nested traces with a large threshold",
 			inputTrace: &Trace{
 				threshold: &thousandMs,
 				stepsTraces: []stepTrace{
-					&Trace{ threshold:&twoThousandMs },
+					&Trace{threshold: &twoThousandMs},
 				},
 			},
-			expectedThreshold: 125*time.Millisecond,
+			expectedThreshold: 125 * time.Millisecond,
 		},
 	}
 

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -69,6 +69,50 @@ func TestStep(t *testing.T) {
 	}
 }
 
+func TestNestedTrace(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputString   string
+		expectedTrace *Trace
+	}{
+		{
+			name:        "Empty string",
+			inputString: "",
+			expectedTrace: &Trace{
+				nestedTrace: []*Trace{
+					{startTime: time.Now(), name: ""},
+				},
+			},
+		},
+		{
+			name:        "Non-empty string",
+			inputString: "Inner trace",
+			expectedTrace: &Trace{
+				nestedTrace: []*Trace{
+					{
+						startTime: time.Now(),
+						name:      "Inner trace",
+						nestedTrace: []*Trace{
+							{name: "Inner trace"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sampleTrace := &Trace{}
+			innerSampleTrace := sampleTrace.Nest(tt.inputString)
+			innerSampleTrace.Nest(tt.inputString)
+			if sampleTrace.nestedTrace[0].name != tt.expectedTrace.nestedTrace[0].name {
+				t.Errorf("Expected %v \n Got %v \n", tt.expectedTrace, sampleTrace)
+			}
+		})
+	}
+}
+
 func TestTotalTime(t *testing.T) {
 	test := struct {
 		name       string
@@ -113,7 +157,7 @@ func TestLog(t *testing.T) {
 		{
 			name: "Check formatting",
 			expectedMessages: []string{
-				"URL:/api,count:3", "msg1 str:text,int:2,bool:false", "msg2 x:1",
+				"URL:/api,count:3", `"msg1" str:text,int:2,bool:false`, `"msg2" x:1`,
 			},
 			sampleTrace: &Trace{
 				name:   "Sample Trace",
@@ -127,7 +171,7 @@ func TestLog(t *testing.T) {
 		{
 			name: "Check fixture formatted",
 			expectedMessages: []string{
-				"URL:/api,count:3", "msg1 str:text,int:2,bool:false", "msg2 x:1",
+				"URL:/api,count:3", `"msg1" str:text,int:2,bool:false`, `"msg2" x:1`,
 			},
 			sampleTrace: fieldsTraceFixture(),
 		},

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -42,8 +42,8 @@ func TestStep(t *testing.T) {
 			name:        "When string is empty",
 			inputString: "",
 			expectedTrace: &Trace{
-				steps: []traceStep{
-					{stepTime: time.Now(), msg: ""},
+				stepsTraces: []stepTrace{
+					traceStep{stepTime: time.Now(), msg: ""},
 				},
 			},
 		},
@@ -51,8 +51,8 @@ func TestStep(t *testing.T) {
 			name:        "When string is not empty",
 			inputString: "test2",
 			expectedTrace: &Trace{
-				steps: []traceStep{
-					{stepTime: time.Now(), msg: "test2"},
+				stepsTraces: []stepTrace{
+					traceStep{stepTime: time.Now(), msg: "test2"},
 				},
 			},
 		},
@@ -62,7 +62,7 @@ func TestStep(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sampleTrace := &Trace{}
 			sampleTrace.Step(tt.inputString)
-			if sampleTrace.steps[0].msg != tt.expectedTrace.steps[0].msg {
+			if sampleTrace.stepsTraces[0].(traceStep).msg != tt.expectedTrace.stepsTraces[0].(traceStep).msg {
 				t.Errorf("Expected %v \n Got %v \n", tt.expectedTrace, sampleTrace)
 			}
 		})
@@ -79,8 +79,8 @@ func TestNestedTrace(t *testing.T) {
 			name:        "Empty string",
 			inputString: "",
 			expectedTrace: &Trace{
-				nestedTrace: []*Trace{
-					{startTime: time.Now(), name: ""},
+				stepsTraces: []stepTrace{
+					&Trace{startTime: time.Now(), name: ""},
 				},
 			},
 		},
@@ -88,12 +88,12 @@ func TestNestedTrace(t *testing.T) {
 			name:        "Non-empty string",
 			inputString: "Inner trace",
 			expectedTrace: &Trace{
-				nestedTrace: []*Trace{
-					{
+				stepsTraces: []stepTrace{
+					&Trace{
 						startTime: time.Now(),
 						name:      "Inner trace",
-						nestedTrace: []*Trace{
-							{name: "Inner trace"},
+						stepsTraces: []stepTrace{
+							&Trace{name: "Inner trace"},
 						},
 					},
 				},
@@ -106,7 +106,7 @@ func TestNestedTrace(t *testing.T) {
 			sampleTrace := &Trace{}
 			innerSampleTrace := sampleTrace.Nest(tt.inputString)
 			innerSampleTrace.Nest(tt.inputString)
-			if sampleTrace.nestedTrace[0].name != tt.expectedTrace.nestedTrace[0].name {
+			if sampleTrace.stepsTraces[0].(*Trace).name != tt.expectedTrace.stepsTraces[0].(*Trace).name {
 				t.Errorf("Expected %v \n Got %v \n", tt.expectedTrace, sampleTrace)
 			}
 		})
@@ -147,10 +147,10 @@ func TestLog(t *testing.T) {
 			},
 			sampleTrace: &Trace{
 				name: "Sample Trace",
-				steps: []traceStep{
-					{stepTime: time.Now(), msg: "msg1"},
-					{stepTime: time.Now(), msg: "msg2"},
-					{stepTime: time.Now(), msg: "msg3"},
+				stepsTraces: []stepTrace{
+					&traceStep{stepTime: time.Now(), msg: "msg1"},
+					&traceStep{stepTime: time.Now(), msg: "msg2"},
+					&traceStep{stepTime: time.Now(), msg: "msg3"},
 				},
 			},
 		},
@@ -162,9 +162,10 @@ func TestLog(t *testing.T) {
 			sampleTrace: &Trace{
 				name:   "Sample Trace",
 				fields: []Field{{"URL", "/api"}, {"count", 3}},
-				steps: []traceStep{
-					{stepTime: time.Now(), msg: "msg1", fields: []Field{{"str", "text"}, {"int", 2}, {"bool", false}}},
-					{stepTime: time.Now(), msg: "msg2", fields: []Field{{"x", "1"}}},
+				stepsTraces: []stepTrace{
+					&traceStep{stepTime: time.Now(), msg: "msg1", fields: []Field{{"str", "text"}, {"int", 2}, {"bool",
+						false}}},
+					&traceStep{stepTime: time.Now(), msg: "msg2", fields: []Field{{"x", "1"}}},
 				},
 			},
 		},
@@ -206,10 +207,10 @@ func TestNestedTraceLog(t *testing.T) {
 			},
 			sampleTrace: &Trace{
 				name: "Sample Trace",
-				nestedTrace: []*Trace{
-					{startTime: time.Now(), name: "msg1"},
-					{startTime: time.Now(), name: "msg2"},
-					{startTime: time.Now(), name: "msg3"},
+				stepsTraces: []stepTrace{
+					&Trace{startTime: time.Now(), name: "msg1"},
+					&Trace{startTime: time.Now(), name: "msg2"},
+					&Trace{startTime: time.Now(), name: "msg3"},
 				},
 			},
 		},
@@ -220,15 +221,13 @@ func TestNestedTraceLog(t *testing.T) {
 			},
 			sampleTrace: &Trace{
 				name: "Sample Trace",
-				nestedTrace: []*Trace{
-					{startTime: time.Now(), name: "msg1"},
-					{startTime: time.Now(), name: "msg2"},
-					{startTime: time.Now(), name: "msg3"},
-				},
-				steps: []traceStep{
-					{stepTime: time.Now(), msg: "step1"},
-					{stepTime: time.Now(), msg: "step2"},
-					{stepTime: time.Now(), msg: "step3"},
+				stepsTraces: []stepTrace{
+					&Trace{startTime: time.Now(), name: "msg1"},
+					&Trace{startTime: time.Now(), name: "msg2"},
+					&Trace{startTime: time.Now(), name: "msg3"},
+					&traceStep{stepTime: time.Now(), msg: "step1"},
+					&traceStep{stepTime: time.Now(), msg: "step2"},
+					&traceStep{stepTime: time.Now(), msg: "step3"},
 				},
 			},
 		},
@@ -239,8 +238,8 @@ func TestNestedTraceLog(t *testing.T) {
 			},
 			sampleTrace: &Trace{
 				name: "Sample Trace",
-				nestedTrace: []*Trace{
-					{startTime: time.Now(), name: "msg1", fields: []Field{{"str", "text"}, {"int", 2}, {"bool",
+				stepsTraces: []stepTrace{
+					&Trace{startTime: time.Now(), name: "msg1", fields: []Field{{"str", "text"}, {"int", 2}, {"bool",
 						false}}},
 				},
 			},
@@ -252,11 +251,11 @@ func TestNestedTraceLog(t *testing.T) {
 			},
 			sampleTrace: &Trace{
 				name: "Sample Trace",
-				nestedTrace: []*Trace{
-					{
+				stepsTraces: []stepTrace{
+					&Trace{
 						startTime:   time.Now(),
 						name:        "msg1",
-						nestedTrace: []*Trace{{name: "nested1", startTime: time.Now()}},
+						stepsTraces: []stepTrace{&Trace{name: "nested1", startTime: time.Now()}},
 					},
 				},
 			},
@@ -352,10 +351,9 @@ func TestLogIfLong(t *testing.T) {
 			klog.SetOutput(&buf)
 
 			tt.sampleTrace = New("Test trace")
-
-			for index, mod := range tt.mutateInfo {
-				tt.sampleTrace.Step(mod.msg)
-				tt.sampleTrace.steps[index].stepTime = currentTime.Add(mod.delay)
+			for _, mod := range tt.mutateInfo {
+				tt.sampleTrace.stepsTraces = append(tt.sampleTrace.stepsTraces,
+					&traceStep{stepTime: currentTime.Add(mod.delay), msg: mod.msg})
 			}
 
 			tt.sampleTrace.LogIfLong(tt.threshold)
@@ -363,55 +361,6 @@ func TestLogIfLong(t *testing.T) {
 			for _, msg := range tt.expectedMessages {
 				if msg != "" && !strings.Contains(buf.String(), msg) {
 					t.Errorf("Msg %q expected in trace log: \n%v\n", msg, buf.String())
-				}
-			}
-		})
-	}
-}
-
-func TestSortedTrace(t *testing.T) {
-	now := time.Now()
-	tenSecLater := now.Add(10 * time.Second)
-	fiveSecLater := now.Add(5 * time.Second)
-	tenSecEarly := now.Add(-10 * time.Second)
-	tests := []struct {
-		name        string
-		inputTrace  *Trace
-		sortedTrace []stepTrace
-	}{
-		{
-			name: "Sort trace and step",
-			inputTrace: &Trace{
-				name: "Sample Trace",
-				nestedTrace: []*Trace{
-					{name: "nested", startTime: tenSecLater},
-					{name: "nested", startTime: fiveSecLater},
-				},
-				steps: []traceStep{
-					{stepTime: now, msg: "step"},
-					{stepTime: tenSecEarly, msg: "step"},
-				},
-			},
-			sortedTrace: []stepTrace{
-				traceStep{stepTime: tenSecEarly, msg: "step"},
-				traceStep{stepTime: now, msg: "step"},
-				&Trace{name: "nested", startTime: fiveSecLater},
-				&Trace{name: "nested", startTime: tenSecLater},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sampleSortedTrace := tt.inputTrace.sortStepTrace()
-			if len(sampleSortedTrace) != len(tt.sortedTrace) {
-				t.Errorf("Expected trace %v of length %v but got trace %v of lenght %v", tt.sortedTrace,
-					len(tt.sortedTrace), sampleSortedTrace, len(sampleSortedTrace))
-			}
-
-			for i, s := range sampleSortedTrace {
-				if s.time() != tt.sortedTrace[i].time() {
-					t.Errorf("Wrong positions in sorted trace, expected %v but got %v", tt.sortedTrace[i], s)
 				}
 			}
 		})

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -378,43 +378,43 @@ func TestLogNestedTrace(t *testing.T) {
 	five := 5 * time.Millisecond
 	currentTime := time.Now()
 
-	tests := []struct{
-		name string
-		expectedMsgs []string
+	tests := []struct {
+		name          string
+		expectedMsgs  []string
 		unexpectedMsg []string
-		trace *Trace
+		trace         *Trace
 	}{
 		{
-			name: "Log nested trace when it surpasses threshold",
-			expectedMsgs: []string{"inner1"},
+			name:          "Log nested trace when it surpasses threshold",
+			expectedMsgs:  []string{"inner1"},
 			unexpectedMsg: []string{"msg"},
 			trace: &Trace{
-				name: "msg",
+				name:      "msg",
 				startTime: currentTime.Add(10),
 				stepsTraces: []stepTrace{
 					&Trace{
-						name: "inner1",
+						name:      "inner1",
 						threshold: &five,
-						startTime: currentTime.Add(-10* time.Millisecond),
+						startTime: currentTime.Add(-10 * time.Millisecond),
 					},
 				},
 			},
 		},
 		{
-			name: "Log inner nested trace when it surpasses threshold",
-			expectedMsgs: []string{"inner inner"},
+			name:          "Log inner nested trace when it surpasses threshold",
+			expectedMsgs:  []string{"inner inner"},
 			unexpectedMsg: []string{"msg", "inner1"},
 			trace: &Trace{
-				name: "msg",
+				name:      "msg",
 				startTime: currentTime.Add(10),
 				stepsTraces: []stepTrace{
 					&Trace{
 						name: "inner1",
 						stepsTraces: []stepTrace{
 							&Trace{
-								name: "inner inner",
+								name:      "inner inner",
 								threshold: &five,
-								startTime: currentTime.Add(-10* time.Millisecond),
+								startTime: currentTime.Add(-10 * time.Millisecond),
 							},
 						},
 					},

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -377,7 +377,7 @@ func TestSortedTrace(t *testing.T) {
 	tests := []struct {
 		name        string
 		inputTrace  *Trace
-		sortedTrace []stepTraceTime
+		sortedTrace []stepTrace
 	}{
 		{
 			name: "Sort trace and step",
@@ -392,7 +392,7 @@ func TestSortedTrace(t *testing.T) {
 					{stepTime: tenSecEarly, msg: "step"},
 				},
 			},
-			sortedTrace: []stepTraceTime{
+			sortedTrace: []stepTrace{
 				traceStep{stepTime: tenSecEarly, msg: "step"},
 				traceStep{stepTime: now, msg: "step"},
 				&Trace{name: "nested", startTime: fiveSecLater},

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -18,6 +18,7 @@ package trace
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"os"
 	"strings"
@@ -580,6 +581,28 @@ func TestStepThreshold(t *testing.T) {
 		if actualThreshold != tt.expectedThreshold {
 			t.Errorf("Expecting %v threshold but got %v", tt.expectedThreshold, actualThreshold)
 		}
+	}
+}
+
+func TestContext(t *testing.T) {
+	ctx := context.Background()
+
+	trace1 := FromContext(ctx).Nest("op1")
+	ctx = ContextWithTrace(ctx, trace1)
+	defer trace1.Log()
+	func(ctx context.Context) {
+		trace2 := FromContext(ctx).Nest("op2")
+		defer trace2.Log()
+	}(ctx)
+	if len(trace1.traceItems) != 1 {
+		t.Fatalf("expected len(trace1.traceItems) == 1, but got %d", len(trace1.traceItems))
+	}
+	nested, ok := trace1.traceItems[0].(*Trace)
+	if !ok {
+		t.Fatal("expected trace1.traceItems[0] to be a nested trace")
+	}
+	if nested.name != "op2" {
+		t.Errorf("expected trace named op2 to be nested in op1, but got %s", nested.name)
 	}
 }
 


### PR DESCRIPTION
This PR adds the NestedTrace to the Trace and also formats the output so that it is more concise. A use case for the nested trace [kubernetes#79209]. (https://github.com/kubernetes/kubernetes/issues/79209)

Example of old output:
`
Trace[866828359]: "Create /api/v1/namespaces/default/pods" (started: 2019-03-11 08:20:14.448210695 +0000 UTC m=+579.430813234) (total time: 14.520559394s):
Trace[866828359]: [165.764543ms] [149.545551ms] Object stored in database
Trace[866828359]: [14.304157451s] [14.138392908s] Writing response
Trace[866828359]: [14.520559394s] [216.401943ms] END
`

There is no nested trace and related traces were logged separately.

Sample of the new, concise output with nested trace 

![image](https://user-images.githubusercontent.com/34774756/74805170-a276c280-52e2-11ea-893b-8a993f43012e.png)

