### PR TITLE
Fix mount_windows build error

### DIFF
--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -80,7 +80,7 @@ func (mounter *Mounter) MountSensitive(source string, target string, fstype stri
 	bindSource := source
 
 	// tell it's going to mount azure disk or azure file according to options
-	if bind, _, _, _ := MakeBindOpts(options, sensitiveOptions); bind {
+	if bind, _, _, _ := MakeBindOptsSensitive(options, sensitiveOptions); bind {
 		// mount azure disk
 		bindSource = NormalizeWindowsPath(source)
 	} else {


### PR DESCRIPTION
https://github.com/kubernetes/utils/pull/138 introduced a build error for `mount_windows.go`
This PR fixes that.
This was caught while trying to integrate with k/k in https://github.com/kubernetes/kubernetes/pull/88684
Opened  https://github.com/kubernetes/utils/issues/142 to track work to prevent such future regressions.