### PR TITLE
Ignore xfs dirty logs

### DIFF
--- a/mount/safe_format_and_mount_test.go
+++ b/mount/safe_format_and_mount_test.go
@@ -241,6 +241,15 @@ func TestSafeFormatAndMount(t *testing.T) {
 			expErrorType: HasFilesystemErrors,
 		},
 		{
+			description: "Test that 'xfs_repair' is called twice and report a dirty log (return 2)",
+			fstype:      "xfs",
+			execScripts: []ExecArgs{
+				{"blkid", []string{"-p", "-s", "TYPE", "-s", "PTTYPE", "-o", "export", "/dev/foo"}, "DEVNAME=/dev/foo\nTYPE=xfs\n", nil},
+				{"xfs_repair", []string{"-n", "/dev/foo"}, "", &testingexec.FakeExitError{Status: 1}},
+				{"xfs_repair", []string{"/dev/foo"}, "\nAn error occurred\n", &testingexec.FakeExitError{Status: 2}},
+			},
+		},
+		{
 			description:           "Test that 'blkid' is called and confirms unformatted disk, format fails with sensitive options",
 			fstype:                "ext4",
 			sensitiveMountOptions: []string{"mySecret"},


### PR DESCRIPTION
This PR try to fix the urgent issue #141  by ignoring the xfs dirty logs issue (do not replay dirty logs by default), and letting subsequent operations handle it.
But this is not a perfect solution, more discussion is in pr #132 .