### PR TITLE
Fix the bug that GetIndexedIP does not support IPv6

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -152,17 +152,17 @@ func ParsePort(port string, allowZero bool) (int, error) {
 
 // BigForIP creates a big.Int based on the provided net.IP
 func BigForIP(ip net.IP) *big.Int {
-	b := ip.To4()
-	if b == nil {
-		b = ip.To16()
-	}
-	return big.NewInt(0).SetBytes(b)
+	// NOTE: Convert to 16-byte representation so we don't can
+	// handle v4 and v6 values the same way.
+	return big.NewInt(0).SetBytes(ip.To16())
 }
 
-// AddIPOffset adds the provided integer offset to a base big.Int representing a
-// net.IP
+// AddIPOffset adds the provided integer offset to a base big.Int representing a net.IP
+// NOTE: If you started with a v4 address and overflow it, you get a v6 result.
 func AddIPOffset(base *big.Int, offset int) net.IP {
-	return net.IP(big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes())
+	r := big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes()
+	r = append(make([]byte, 16), r...)
+	return net.IP(r[len(r)-16:])
 }
 
 // RangeSize returns the size of a range in valid addresses.

--- a/net/net.go
+++ b/net/net.go
@@ -152,7 +152,7 @@ func ParsePort(port string, allowZero bool) (int, error) {
 
 // BigForIP creates a big.Int based on the provided net.IP
 func BigForIP(ip net.IP) *big.Int {
-	// NOTE: Convert to 16-byte representation so we don't can
+	// NOTE: Convert to 16-byte representation so we can
 	// handle v4 and v6 values the same way.
 	return big.NewInt(0).SetBytes(ip.To16())
 }

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -582,6 +582,34 @@ func TestGetIndexedIP(t *testing.T) {
 			expectError: false,
 			expectedIP:  "192.168.1.255",
 		},
+		{
+			cidr:        "255.255.255.0/24",
+			index:       256,
+			expectError: true,
+		},
+		{
+			cidr:        "fd:11:b2:be::/120",
+			index:       20,
+			expectError: false,
+			expectedIP:  "fd:11:b2:be::14",
+		},
+		{
+			cidr:        "fd:11:b2:be::/126",
+			index:       10,
+			expectError: true,
+		},
+		{
+			cidr:        "fd:11:b2:be::/120",
+			index:       255,
+			expectError: false,
+			expectedIP:  "fd:11:b2:be::ff",
+		},
+		{
+			cidr:        "00:00:00:be::/120",
+			index:       255,
+			expectError: false,
+			expectedIP:  "::be:0:0:0:ff",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Signed-off-by: SataQiu <1527062125@qq.com>

Ref: kubernetes/kubernetes#88933

The reason is that the returned byte slice of `big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes()` does not include the leading zero byte.
We need to check and correct the length of the byte slice before converting it to IP.