### PR TITLE
Fix subPath mountpint check

### DIFF
--- a/mount/mount_helper_common.go
+++ b/mount/mount_helper_common.go
@@ -48,9 +48,9 @@ func CleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointC
 // if corruptedMnt is true, it means that the mountPath is a corrupted mountpoint, and the mount point check
 // will be skipped
 func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool, corruptedMnt bool) error {
+	var notMnt bool
+	var err error
 	if !corruptedMnt {
-		var notMnt bool
-		var err error
 		if extensiveMountPointCheck {
 			notMnt, err = IsNotMountPoint(mounter, mountPath)
 		} else {
@@ -73,9 +73,13 @@ func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPoin
 		return err
 	}
 
-	notMnt, mntErr := mounter.IsLikelyNotMountPoint(mountPath)
-	if mntErr != nil {
-		return mntErr
+	if extensiveMountPointCheck {
+		notMnt, err = IsNotMountPoint(mounter, mountPath)
+	} else {
+		notMnt, err = mounter.IsLikelyNotMountPoint(mountPath)
+	}
+	if err != nil {
+		return err
 	}
 	if notMnt {
 		klog.V(4).Infof("%q is unmounted, deleting the directory", mountPath)


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

This PR enables proper extensiveMountPointCheck for checking subPath volumes

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/89181

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```