### PR TITLE
fix for no Go source files on macOS

### DIFF
--- a/inotify/inotify.go
+++ b/inotify/inotify.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inotify // import "k8s.io/utils/inotify"
+
+import (
+	"sync"
+)
+
+// Event represents a notification
+type Event struct {
+	Mask   uint32 // Mask of events
+	Cookie uint32 // Unique cookie associating related events (for rename(2))
+	Name   string // File name (optional)
+}
+
+type watch struct {
+	wd    uint32 // Watch descriptor (as returned by the inotify_add_watch() syscall)
+	flags uint32 // inotify flags of this watch (see inotify(7) for the list of valid flags)
+}
+
+// Watcher represents an inotify instance
+type Watcher struct {
+	mu       sync.Mutex
+	fd       int               // File descriptor (as returned by the inotify_init() syscall)
+	watches  map[string]*watch // Map of inotify watches (key: path)
+	paths    map[int]string    // Map of watched paths (key: watch descriptor)
+	Error    chan error        // Errors are sent on this channel
+	Event    chan *Event       // Events are returned on this channel
+	done     chan bool         // Channel for sending a "quit message" to the reader goroutine
+	isClosed bool              // Set to true when Close() is first called
+}

--- a/inotify/inotify_linux.go
+++ b/inotify/inotify_linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 // Copyright 2010 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -31,34 +33,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"syscall"
 	"unsafe"
 )
-
-// Event represents a notification
-type Event struct {
-	Mask   uint32 // Mask of events
-	Cookie uint32 // Unique cookie associating related events (for rename(2))
-	Name   string // File name (optional)
-}
-
-type watch struct {
-	wd    uint32 // Watch descriptor (as returned by the inotify_add_watch() syscall)
-	flags uint32 // inotify flags of this watch (see inotify(7) for the list of valid flags)
-}
-
-// Watcher represents an inotify instance
-type Watcher struct {
-	mu       sync.Mutex
-	fd       int               // File descriptor (as returned by the inotify_init() syscall)
-	watches  map[string]*watch // Map of inotify watches (key: path)
-	paths    map[int]string    // Map of watched paths (key: watch descriptor)
-	Error    chan error        // Errors are sent on this channel
-	Event    chan *Event       // Events are returned on this channel
-	done     chan bool         // Channel for sending a "quit message" to the reader goroutine
-	isClosed bool              // Set to true when Close() is first called
-}
 
 // NewWatcher creates and returns a new inotify instance using inotify_init(2)
 func NewWatcher() (*Watcher, error) {

--- a/inotify/inotify_others.go
+++ b/inotify/inotify_others.go
@@ -1,0 +1,54 @@
+// +build !linux
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inotify // import "k8s.io/utils/inotify"
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var errNotSupported = fmt.Errorf("watch not supported on %s", runtime.GOOS)
+
+// NewWatcher creates and returns a new inotify instance using inotify_init(2)
+func NewWatcher() (*Watcher, error) {
+	return nil, errNotSupported
+}
+
+// Close closes an inotify watcher instance
+// It sends a message to the reader goroutine to quit and removes all watches
+// associated with the inotify instance
+func (w *Watcher) Close() error {
+	return errNotSupported
+}
+
+// AddWatch adds path to the watched file set.
+// The flags are interpreted as described in inotify_add_watch(2).
+func (w *Watcher) AddWatch(path string, flags uint32) error {
+	return errNotSupported
+}
+
+// Watch adds path to the watched file set, watching all events.
+func (w *Watcher) Watch(path string) error {
+	return errNotSupported
+}
+
+// RemoveWatch removes path from the watched file set.
+func (w *Watcher) RemoveWatch(path string) error {
+	return errNotSupported
+}


### PR DESCRIPTION
Make things a bit more easier on macOS
```
~/go/src/github.com/google/cadvisor
$ go list all
build k8s.io/utils/inotify: cannot load k8s.io/utils/inotify: no Go source files
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>