### PR TITLE
Fix OverlayFS mountpoint check for files

### DIFF
--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -261,6 +261,11 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	if err != nil {
 		return true, err
 	}
+	// This check is not applicable to files due to the fact that some filesystems like
+	// OverlayFS may show different devices for the file and its parent directory
+	if !stat.IsDir() {
+		return true, nil
+	}
 	rootStat, err := os.Stat(filepath.Dir(strings.TrimSuffix(file, "/")))
 	if err != nil {
 		return true, err


### PR DESCRIPTION
This PR disables `IsLikelyNotMountPoint()` check for files, because it might give a false positive result in case if `/var/lib/kubelet` is located on overlayfs filesystem, eg:

```bash
mkdir /tmp/overlayfs-test

mkdir /tmp/overlayfs-test/{upper,work,mount}

sudo mount -t overlay -o rw,relatime,lowerdir=/,upperdir=/tmp/overlayfs-test/upper/,workdir=/tmp/overlayfs-test/work/ none /tmp/overlayfs-test/mount/

mkdir -p /tmp/overlayfs-test/mount/some/dir/

touch /tmp/overlayfs-test/mount/some/dir/some_file
```

Then try simulate `IsLikelyNotMountPoint()` check:
```console
sh-5.0$ df -h /tmp/overlayfs-test/mount/some/dir/some_file
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           3.7G   16K  3.7G   1% /tmp

sh-5.0$ df -h /tmp/overlayfs-test/mount/some/dir/
Filesystem      Size  Used Avail Use% Mounted on
none            3.7G   16K  3.7G   1% /tmp/overlayfs-test/mount
```

Since devices for file and for parent directory are different it will retrurn `false` (means is mountpoint), but it is actually doesn't:

```console
sh-5.0$ readlink -f /tmp/overlayfs-test/mount/some/dir/some_file 
/tmp/overlayfs-test/mount/some/dir/some_file

sh-5.0$ mountpoint /tmp/overlayfs-test/mount/some/dir/some_file 
/tmp/overlayfs-test/mount/some/dir/some_file is not a mountpoint
```

I can reproduce it on `4.15.18-24-pve` and `5.5.2-arch1-1` kernels

---

This PR completely fixes https://github.com/kubernetes/kubernetes/issues/89181#issuecomment-617326253

We also should consider reverting https://github.com/kubernetes/utils/pull/147, because it does not solves the original bug.

I've tested both cases with reverting and without it. Both are working fine to me.