### PR TITLE
mount: force unique scope names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/google/uuid v1.1.1
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.3.0
 	k8s.io/klog/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=


### PR DESCRIPTION
Some of the older distros (Debian 8.0, Centos 7.8, Ubuntu 14.04 LTS) use systemd,
which uses PIDs for scope names:

https://lists.freedesktop.org/archives/systemd-devel/2015-October/034591.html

This was fixed in the systemd >=228, commit systemd/systemd@9c8d1e1, but
for the time being, we need to support these older distros.

The idea is to force scope names to use UUID. The chance for the
collision is small enough to be negligible (128 bits) so that checking for pre-existsing scope names is not necessary.

Related GitHub issue: https://github.com/kubernetes/kubernetes/issues/90327