### PR TITLE
Remove driver letter assignment during volume format

### DIFF
--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"k8s.io/klog/v2"
-	utilexec "k8s.io/utils/exec"
 	"k8s.io/utils/keymutex"
 	utilpath "k8s.io/utils/path"
 )
@@ -230,17 +229,17 @@ func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target
 
 	// format disk if it is unformatted(raw)
 	cmd := fmt.Sprintf("Get-Disk -Number %s | Where partitionstyle -eq 'raw' | Initialize-Disk -PartitionStyle MBR -PassThru"+
-		" | New-Partition -AssignDriveLetter -UseMaximumSize | Format-Volume -FileSystem %s -Confirm:$false", source, fstype)
+		" | New-Partition -UseMaximumSize | Format-Volume -FileSystem %s -Confirm:$false", source, fstype)
 	if output, err := mounter.Exec.Command("powershell", "/c", cmd).CombinedOutput(); err != nil {
 		return fmt.Errorf("diskMount: format disk failed, error: %v, output: %q", err, string(output))
 	}
 	klog.V(4).Infof("diskMount: Disk successfully formatted, disk: %q, fstype: %q", source, fstype)
 
-	driveLetter, err := getDriveLetterByDiskNumber(source, mounter.Exec)
+	volumeIds, err := listVolumesOnDisk(source)
 	if err != nil {
 		return err
 	}
-	driverPath := driveLetter + ":"
+	driverPath := volumeIds[0]
 	target = NormalizeWindowsPath(target)
 	klog.V(4).Infof("Attempting to formatAndMount disk: %s %s %s", fstype, driverPath, target)
 	if output, err := mounter.Exec.Command("cmd", "/c", "mklink", "/D", target, driverPath).CombinedOutput(); err != nil {
@@ -250,17 +249,17 @@ func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target
 	return nil
 }
 
-// Get drive letter according to windows disk number
-func getDriveLetterByDiskNumber(diskNum string, exec utilexec.Interface) (string, error) {
-	cmd := fmt.Sprintf("(Get-Partition -DiskNumber %s).DriveLetter", diskNum)
+// ListVolumesOnDisk - returns back list of volumes(volumeIDs) in the disk (requested in diskID).
+func listVolumesOnDisk(diskID string) (volumeIDs []string, err error) {
+	cmd := fmt.Sprintf("(Get-Disk -DeviceId %s | Get-Partition | Get-Volume).UniqueId", diskID)
 	output, err := exec.Command("powershell", "/c", cmd).CombinedOutput()
+	klog.V(4).Infof("listVolumesOnDisk id from %s: %s", diskID, string(output))
 	if err != nil {
-		return "", fmt.Errorf("azureMount: Get Drive Letter failed: %v, output: %q", err, string(output))
+		return []string{}, fmt.Errorf("error list volumes on disk. cmd: %s, output: %s, error: %v", cmd, string(output), err)
 	}
-	if len(string(output)) < 1 {
-		return "", fmt.Errorf("azureMount: Get Drive Letter failed, output is empty")
-	}
-	return string(output)[:1], nil
+
+	volumeIds := strings.Split(strings.TrimSpace(string(output)), "\r\n")
+	return volumeIds, nil
 }
 
 // getAllParentLinks walks all symbolic links and return all the parent targets recursively


### PR DESCRIPTION
This PR removes the driver letter assignment during volume format and
mount because driver letter might run out and cause issues during mount.
Intead, it uses volume id to mount the target dir.