### PR TITLE
fix: remove unnecessary readlink check in IsLikelyNotMountPoint on Windows

### DIFF
--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -113,10 +113,12 @@ func (mounter *Mounter) MountSensitive(source string, target string, fstype stri
 		}
 	}
 
-	if output, err := exec.Command("cmd", "/c", "mklink", "/D", target, bindSource).CombinedOutput(); err != nil {
+	output, err := exec.Command("cmd", "/c", "mklink", "/D", target, bindSource).CombinedOutput()
+	if err != nil {
 		klog.Errorf("mklink failed: %v, source(%q) target(%q) output: %q", err, bindSource, target, string(output))
 		return err
 	}
+	klog.V(2).Infof("mklink source(%q) on target(%q) successfully, output: %q", bindSource, target, string(output))
 
 	return nil
 }
@@ -229,13 +231,14 @@ func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target
 	if err != nil {
 		return err
 	}
-	driverPath := volumeIds[0]
+	volumeID := volumeIds[0]
 	target = NormalizeWindowsPath(target)
-	klog.V(4).Infof("Attempting to formatAndMount disk: %s %s %s", fstype, driverPath, target)
-	if output, err := mounter.Exec.Command("cmd", "/c", "mklink", "/D", target, driverPath).CombinedOutput(); err != nil {
-		klog.Errorf("mklink failed: %v, output: %q", err, string(output))
+	output, err := mounter.Exec.Command("cmd", "/c", "mklink", "/D", target, volumeID).CombinedOutput()
+	if err != nil {
+		klog.Errorf("mklink(%s, %s) failed: %v, output: %q", target, volumeID, err, string(output))
 		return err
 	}
+	klog.V(2).Infof("formatAndMount disk(%s) fstype(%s) on(%s) with output(%s) successfully", volumeID, fstype, target, string(output))
 	return nil
 }
 

--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -27,7 +27,6 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/utils/keymutex"
-	utilpath "k8s.io/utils/path"
 )
 
 // Mounter provides the default implementation of mount.Interface
@@ -182,19 +181,10 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	if err != nil {
 		return true, err
 	}
-	// If current file is a symlink, then it is a mountpoint.
-	if stat.Mode()&os.ModeSymlink != 0 {
-		target, err := os.Readlink(file)
-		if err != nil {
-			return true, fmt.Errorf("readlink error: %v", err)
-		}
-		exists, err := utilpath.Exists(utilpath.CheckFollowSymlink, target)
-		if err != nil {
-			return true, err
-		}
-		return !exists, nil
-	}
 
+	if stat.Mode()&os.ModeSymlink != 0 {
+		return false, err
+	}
 	return true, nil
 }
 


### PR DESCRIPTION
with this PR, I have verified unmount volumeid issue could be fixed on Windows, below are the debugging logs, details could be found [here](https://github.com/kubernetes/kubernetes/pull/91468#discussion_r433122906):
```
I0602 12:53:01.696359    8140 mount_windows.go:205] Attempting to formatAndMount disk:  2 \var\lib\kubelet\plugins\kubernetes.io\azure-disk\mounts\m2278753155
I0602 12:53:04.801422    8140 mount_windows.go:223] diskMount: Disk successfully formatted, disk: "2", fstype: "NTFS"
I0602 12:53:05.558586    8140 mount_windows.go:67] mounting source ("tmpfs"), target ("c:\\var\\lib\\kubelet\\pods\\5c06e0e1-7cbc-4222-9e13-4ba473c53599\\volumes\\kubernetes.io~secret\\csi-azuredisk-node-sa-token-txbvq"), with options ("")
I0602 12:53:07.306064    8140 mount_windows.go:245] listVolumesOnDisk id from 2: \\?\Volume{815a1f70-0000-0000-0000-100000000000}\
I0602 12:53:07.306064    8140 mount_windows.go:231] Attempting to formatAndMount disk: NTFS \\?\Volume{815a1f70-0000-0000-0000-100000000000}\ c:\var\lib\kubelet\plugins\kubernetes.io\azure-disk\mounts\m2278753155
I0602 12:53:07.324066    8140 mount_windows.go:237] mklink output(symbolic link created for c:\var\lib\kubelet\plugins\kubernetes.io\azure-disk\mounts\m2278753155 <<===>> \\?\Volume{815a1f70-0000-0000-0000-100000000000}\
I0602 12:53:07.328065    8140 mount_windows.go:76] mount options("bind") source:"\\var\\lib\\kubelet\\plugins\\kubernetes.io\\azure-disk\\mounts\\m2278753155", target:"c:\\var\\lib\\kubelet\\pods\\5d892c20-03a6-4312-a013-ca431b81a8f9\\volumes\\kubernetes.io~azure-disk\\pvc-43c9acef-d0f7-448a-89d0-2d7c44ba8ec8", fstype:"", begin to mount
I0602 12:53:07.897282    8140 mount_windows.go:67] mounting source ("tmpfs"), target ("c:\\var\\lib\\kubelet\\pods\\4261be62-86b9-4f99-91b5-dd77a9a41c22\\volumes\\kubernetes.io~secret\\csi-azurefile-node-sa-token-2n97x"), with options ("")
I0602 12:53:08.762728    8140 mount_windows.go:67] mounting source ("tmpfs"), target ("c:\\var\\lib\\kubelet\\pods\\4261be62-86b9-4f99-91b5-dd77a9a41c22\\volumes\\kubernetes.io~secret\\csi-azurefile-node-sa-token-2n97x"), with options ("")
I0602 12:53:08.766729    8140 mount_windows.go:67] mounting source ("tmpfs"), target ("c:\\var\\lib\\kubelet\\pods\\5c06e0e1-7cbc-4222-9e13-4ba473c53599\\volumes\\kubernetes.io~secret\\csi-azuredisk-node-sa-token-txbvq"), with options ("")
I0602 12:53:15.603484    8140 mount_windows.go:67] mounting source ("tmpfs"), target ("c:\\var\\lib\\kubelet\\pods\\5d892c20-03a6-4312-a013-ca431b81a8f9\\volumes\\kubernetes.io~secret\\default-token-zmz89"), with options ("")
I0602 12:53:16.613667    8140 mount_windows.go:67] mounting source ("tmpfs"), target ("c:\\var\\lib\\kubelet\\pods\\5d892c20-03a6-4312-a013-ca431b81a8f9\\volumes\\kubernetes.io~secret\\default-token-zmz89"), with options ("")
I0602 12:54:10.543978    8140 mount_windows.go:67] mounting source ("tmpfs"), target ("c:\\var\\lib\\kubelet\\pods\\5c06e0e1-7cbc-4222-9e13-4ba473c53599\\volumes\\kubernetes.io~secret\\csi-azuredisk-node-sa-token-txbvq"), with options ("")
I0602 12:54:23.564186    8140 mount_windows.go:67] mounting source ("tmpfs"), target ("c:\\var\\lib\\kubelet\\pods\\4261be62-86b9-4f99-91b5-dd77a9a41c22\\volumes\\kubernetes.io~secret\\csi-azurefile-node-sa-token-2n97x"), with options ("")
I0602 12:54:25.416216    8140 mount_windows.go:164] azureMount: Unmount target ("c:\\var\\lib\\kubelet\\pods\\5d892c20-03a6-4312-a013-ca431b81a8f9\\volumes\\kubernetes.io~azure-disk\\pvc-43c9acef-d0f7-448a-89d0-2d7c44ba8ec8")
E0602 12:54:25.432452    8140 mount_windows.go:167] rmdir failed: exit status 2, output: "The system cannot find the file specified.\r\n"
```

/assign @jingxu97 