### PR TITLE
Add PtrDerefOr for more types

### DIFF
--- a/pointer/pointer.go
+++ b/pointer/pointer.go
@@ -51,14 +51,23 @@ func Int32Ptr(i int32) *int32 {
 	return &i
 }
 
+// Int32PtrDerefOr dereference the int32 ptr and returns it if not nil,
+// else returns def.
+func Int32PtrDerefOr(ptr *int32, def int32) int32 {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
 // Int64Ptr returns a pointer to an int64
 func Int64Ptr(i int64) *int64 {
 	return &i
 }
 
-// Int32PtrDerefOr dereference the int32 ptr and returns it if not nil,
+// Int64PtrDerefOr dereference the int64 ptr and returns it if not nil,
 // else returns def.
-func Int32PtrDerefOr(ptr *int32, def int32) int32 {
+func Int64PtrDerefOr(ptr *int64, def int64) int64 {
 	if ptr != nil {
 		return *ptr
 	}
@@ -70,9 +79,27 @@ func BoolPtr(b bool) *bool {
 	return &b
 }
 
+// BoolPtrDerefOr dereference the bool ptr and returns it if not nil,
+// else returns def.
+func BoolPtrDerefOr(ptr *bool, def bool) bool {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
 // StringPtr returns a pointer to the passed string.
 func StringPtr(s string) *string {
 	return &s
+}
+
+// StringPtrDerefOr dereference the string ptr and returns it if not nil,
+// else returns def.
+func StringPtrDerefOr(ptr *string, def string) string {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
 }
 
 // Float32Ptr returns a pointer to the passed float32.
@@ -80,7 +107,25 @@ func Float32Ptr(i float32) *float32 {
 	return &i
 }
 
+// Float32PtrDerefOr dereference the float32 ptr and returns it if not nil,
+// else returns def.
+func Float32PtrDerefOr(ptr *float32, def float32) float32 {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
 // Float64Ptr returns a pointer to the passed float64.
 func Float64Ptr(i float64) *float64 {
 	return &i
+}
+
+// Float64PtrDerefOr dereference the float64 ptr and returns it if not nil,
+// else returns def.
+func Float64PtrDerefOr(ptr *float64, def float64) float64 {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
 }

--- a/pointer/pointer_test.go
+++ b/pointer/pointer_test.go
@@ -18,7 +18,6 @@ package pointer
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 )
 
@@ -63,10 +62,177 @@ func TestAllPtrFieldsNil(t *testing.T) {
 	for i, tc := range testCases {
 		name := fmt.Sprintf("case[%d]", i)
 		t.Run(name, func(t *testing.T) {
-			actualErr := AllPtrFieldsNil(tc.obj)
-			if !reflect.DeepEqual(tc.expected, actualErr) {
-				t.Errorf("%s: expected %t, got %t", name, tc.expected, !tc.expected)
+			if actual := AllPtrFieldsNil(tc.obj); actual != tc.expected {
+				t.Errorf("%s: expected %t, got %t", name, tc.expected, actual)
 			}
 		})
+	}
+}
+
+func TestInt32Ptr(t *testing.T) {
+	val := int32(0)
+	ptr := Int32Ptr(val)
+	if *ptr != val {
+		t.Errorf("expected %d, got %d", val, *ptr)
+	}
+
+	val = int32(1)
+	ptr = Int32Ptr(val)
+	if *ptr != val {
+		t.Errorf("expected %d, got %d", val, *ptr)
+	}
+}
+
+func TestInt32PtrDerefOr(t *testing.T) {
+	var val, def int32 = 1, 0
+
+	out := Int32PtrDerefOr(&val, def)
+	if out != val {
+		t.Errorf("expected %d, got %d", val, out)
+	}
+
+	out = Int32PtrDerefOr(nil, def)
+	if out != def {
+		t.Errorf("expected %d, got %d", def, out)
+	}
+}
+
+func TestInt64Ptr(t *testing.T) {
+	val := int64(0)
+	ptr := Int64Ptr(val)
+	if *ptr != val {
+		t.Errorf("expected %d, got %d", val, *ptr)
+	}
+
+	val = int64(1)
+	ptr = Int64Ptr(val)
+	if *ptr != val {
+		t.Errorf("expected %d, got %d", val, *ptr)
+	}
+}
+
+func TestInt64PtrDerefOr(t *testing.T) {
+	var val, def int64 = 1, 0
+
+	out := Int64PtrDerefOr(&val, def)
+	if out != val {
+		t.Errorf("expected %d, got %d", val, out)
+	}
+
+	out = Int64PtrDerefOr(nil, def)
+	if out != def {
+		t.Errorf("expected %d, got %d", def, out)
+	}
+}
+
+func TestBoolPtr(t *testing.T) {
+	val := false
+	ptr := BoolPtr(val)
+	if *ptr != val {
+		t.Errorf("expected %t, got %t", val, *ptr)
+	}
+
+	val = true
+	ptr = BoolPtr(true)
+	if *ptr != val {
+		t.Errorf("expected %t, got %t", val, *ptr)
+	}
+}
+
+func TestBoolPtrDerefOr(t *testing.T) {
+	val, def := true, false
+
+	out := BoolPtrDerefOr(&val, def)
+	if out != val {
+		t.Errorf("expected %t, got %t", val, out)
+	}
+
+	out = BoolPtrDerefOr(nil, def)
+	if out != def {
+		t.Errorf("expected %t, got %t", def, out)
+	}
+}
+
+func TestStringPtr(t *testing.T) {
+	val := ""
+	ptr := StringPtr(val)
+	if *ptr != val {
+		t.Errorf("expected %s, got %s", val, *ptr)
+	}
+
+	val = "a"
+	ptr = StringPtr(val)
+	if *ptr != val {
+		t.Errorf("expected %s, got %s", val, *ptr)
+	}
+}
+
+func TestStringPtrDerefOr(t *testing.T) {
+	val, def := "a", ""
+
+	out := StringPtrDerefOr(&val, def)
+	if out != val {
+		t.Errorf("expected %s, got %s", val, out)
+	}
+
+	out = StringPtrDerefOr(nil, def)
+	if out != def {
+		t.Errorf("expected %s, got %s", def, out)
+	}
+}
+
+func TestFloat32Ptr(t *testing.T) {
+	val := float32(0)
+	ptr := Float32Ptr(val)
+	if *ptr != val {
+		t.Errorf("expected %f, got %f", val, *ptr)
+	}
+
+	val = float32(0.1)
+	ptr = Float32Ptr(val)
+	if *ptr != val {
+		t.Errorf("expected %f, got %f", val, *ptr)
+	}
+}
+
+func TestFloat32PtrDerefOr(t *testing.T) {
+	var val, def float32 = 0.1, 0
+
+	out := Float32PtrDerefOr(&val, def)
+	if out != val {
+		t.Errorf("expected %f, got %f", val, out)
+	}
+
+	out = Float32PtrDerefOr(nil, def)
+	if out != def {
+		t.Errorf("expected %f, got %f", def, out)
+	}
+}
+
+func TestFloat64Ptr(t *testing.T) {
+	val := float64(0)
+	ptr := Float64Ptr(val)
+	if *ptr != val {
+		t.Errorf("expected %f, got %f", val, *ptr)
+	}
+
+	val = float64(0.1)
+	ptr = Float64Ptr(val)
+	if *ptr != val {
+		t.Errorf("expected %f, got %f", val, *ptr)
+	}
+}
+
+func TestFloat64PtrDerefOr(t *testing.T) {
+	var val, def float64 = 0.1, 0
+
+	out := Float64PtrDerefOr(&val, def)
+	if out != val {
+		t.Errorf("expected %f, got %f", val, out)
+	}
+
+	out = Float64PtrDerefOr(nil, def)
+	if out != def {
+		t.Errorf("expected %f, got %f", def, out)
 	}
 }


### PR DESCRIPTION
The `pointer` package currently has `Int32PtrDerefOr`. This PR has added `XPtrDerefOr` for the other types (int64, bool, string, float32, float64). These functions can be useful in dereferencing pointer fields in Kubernetes objects with default values.

`pointer_test.go` is updated to cover all functions in `pointer.go`.