### PR TITLE
fix: smb remount issue

### DIFF
--- a/mount/mount_windows_test.go
+++ b/mount/mount_windows_test.go
@@ -331,3 +331,33 @@ func TestNewSMBMapping(t *testing.T) {
 		}
 	}
 }
+
+func TestIsValidPath(t *testing.T) {
+	tests := []struct {
+		remotepath     string
+		expectedResult bool
+		expectError    bool
+	}{
+		{
+			"c:",
+			true,
+			false,
+		},
+		{
+			"invalid-path",
+			false,
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		result, err := isValidPath(test.remotepath)
+		assert.Equal(t, result, test.expectedResult, "Expect result not equal with isValidPath(%s) return: %q, expected: %q, error: %v",
+			test.remotepath, result, test.expectedResult, err)
+		if test.expectError {
+			assert.NotNil(t, err, "Expect error during isValidPath(%s)", test.remotepath)
+		} else {
+			assert.Nil(t, err, "Expect error is nil during isValidPath(%s)", test.remotepath)
+		}
+	}
+}


### PR DESCRIPTION
This PR could fix https://github.com/kubernetes/kubernetes/issues/93805

https://github.com/kubernetes/kubernetes/pull/73661 not fixed the SMB mount issue totally, when there is a SMB mount with same remote path, original SMB mapping would be removed and SMB mapping re-established, that would cause temporally data inaccessible with the original container. 

#### fix
should use `test-path \\server\share` to check whether original smb mapping is valid, here is an example showing that after SMB server password changed, `Test-Path` could validate whether connection is ok:
```
Microsoft Windows [Version 10.0.17763.1339]
(c) 2018 Microsoft Corporation. All rights reserved.

azureuser@3460k8s000 C:\Users\azureuser>powershell
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

PS C:\Users\azureuser> Get-SmbGlobalMapping

Status Local Path Remote Path
------ ---------- -----------
OK                \\accountname.file.core.windows.net\andy-win1186-dynamic-pvc-b23d5a60-50dd-4c0c-bdc1-f4ff40349609


PS C:\Users\azureuser> Test-Path \\accountname.file.core.windows.net\andy-win1186-dynamic-pvc-b23d5a60-50dd-4c0c-bdc1-f4ff40349609
True

# After SMB server password changed

PS C:\Users\azureuser> Test-Path \\accountname.file.core.windows.net\andy-win1186-dynamic-pvc-b23d5a60-50dd-4c0c-bdc1-f4ff40349609
False

# Get-SmbGlobalMapping status is always OK
PS C:\Users\azureuser> Get-SmbGlobalMapping

Status Local Path Remote Path
------ ---------- -----------
OK                \\fca1c6d57af91439aa77889.file.core.windows.net\andy-win1186-dynamic-pvc-b23d5a60-50dd-4c0c-bdc1-f4ff40349609
```

/assign @msau42 @jingxu97 