### PR TITLE
fix: return error with fewer mount options on Windows

### DIFF
--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -84,9 +84,8 @@ func (mounter *Mounter) MountSensitive(source string, target string, fstype stri
 		allOptions = append(allOptions, options...)
 		allOptions = append(allOptions, sensitiveOptions...)
 		if len(allOptions) < 2 {
-			klog.Warningf("mount options(%q) command number(%d) less than 2, source:%q, target:%q, skip mounting",
+			return fmt.Errorf("mount options(%q) should have at least 2 options, current number:%d, source:%q, target:%q",
 				sanitizedOptionsForLogging, len(allOptions), source, target)
-			return nil
 		}
 
 		// currently only cifs mount is supported


### PR DESCRIPTION

as discussed in https://github.com/kubernetes/utils/pull/180, return error with fewer mount options on Windows
/assign @msau42 @jingxu97 