### PR TITLE
Factor PassiveClock out of Clock

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -18,11 +18,18 @@ package clock
 
 import "time"
 
+// PassiveClock allows for injecting fake or real clocks into code
+// that needs to read the current time but does not support scheduling
+// activity in the future.
+type PassiveClock interface {
+	Now() time.Time
+	Since(time.Time) time.Duration
+}
+
 // Clock allows for injecting fake or real clocks into code that
 // needs to do arbitrary things based on time.
 type Clock interface {
-	Now() time.Time
-	Since(time.Time) time.Duration
+	PassiveClock
 	After(d time.Duration) <-chan time.Time
 	NewTimer(d time.Duration) Timer
 	Sleep(d time.Duration)

--- a/clock/testing/fake_clock_test.go
+++ b/clock/testing/fake_clock_test.go
@@ -19,21 +19,53 @@ package testing
 import (
 	"testing"
 	"time"
+
+	"k8s.io/utils/clock"
 )
+
+type SettablePassiveClock interface {
+	clock.PassiveClock
+	SetTime(time.Time)
+}
+
+func exercisePassiveClock(t *testing.T, pc SettablePassiveClock) {
+	t1 := time.Now()
+	t2 := t1.Add(time.Hour)
+	pc.SetTime(t1)
+	tx := pc.Now()
+	if tx != t1 {
+		t.Errorf("SetTime(%#+v); Now() => %#+v", t1, tx)
+	}
+	dx := pc.Since(t1)
+	if dx != 0 {
+		t.Errorf("Since() => %v", dx)
+	}
+	pc.SetTime(t2)
+	dx = pc.Since(t1)
+	if dx != time.Hour {
+		t.Errorf("Since() => %v", dx)
+	}
+	tx = pc.Now()
+	if tx != t2 {
+		t.Errorf("Now() => %#+v", tx)
+	}
+}
+
+func TestFakePassiveClock(t *testing.T) {
+	startTime := time.Now()
+	tc := NewFakePassiveClock(startTime)
+	exercisePassiveClock(t, tc)
+}
 
 func TestFakeClock(t *testing.T) {
 	startTime := time.Now()
 	tc := NewFakeClock(startTime)
+	exercisePassiveClock(t, tc)
+	tc.SetTime(startTime)
 	tc.Step(time.Second)
 	now := tc.Now()
 	if now.Sub(startTime) != time.Second {
 		t.Errorf("input: %s now=%s gap=%s expected=%s", startTime, now, now.Sub(startTime), time.Second)
-	}
-
-	tt := tc.Now()
-	tc.SetTime(tt.Add(time.Hour))
-	if tc.Now().Sub(tt) != time.Hour {
-		t.Errorf("input: %s now=%s gap=%s expected=%s", tt, tc.Now(), tc.Now().Sub(tt), time.Hour)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR factors PassiveClock out of Clock.  This is good because it heals a difference between the two clock packages (https://github.com/kubernetes/kubernetes/issues/94738) and because I am going to need it when https://github.com/kubernetes/kubernetes/pull/94672 gets far enough to be used in https://github.com/kubernetes/apiserver/blob/master/pkg/util/flowcontrol/metrics/sample_and_watermark.go (see https://github.com/prometheus/client_golang/issues/796 for why that would be done).

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
