### PR TITLE
test: add windows unit test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Build
         run: |
           go build ./...
+      - name: Run Windows Unit Tests
+        run: |
+          $env:GH_ACTION="TRUE"
+          go test -v -race ./mount/...
   test:
     strategy:
       matrix:

--- a/mount/mount_windows_test.go
+++ b/mount/mount_windows_test.go
@@ -133,6 +133,12 @@ func TestPathWithinBase(t *testing.T) {
 }
 
 func TestIsLikelyNotMountPoint(t *testing.T) {
+	if os.Getenv("GH_ACTION") == "TRUE" {
+		// Skip this test on Github Action due to:
+		// Creating a `SymbolicLink` type on Windows requires elevation as administrator
+		// https://github.com/MicrosoftDocs/PowerShell-Docs/pull/3473
+		t.Skip("Skipping test on Github Action")
+	}
 	mounter := Mounter{"fake/path"}
 
 	tests := []struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
test: add windows unit test action
Need to disable one ut since it requires admin privileges,  cannot solve it in github action

```
C:\Users\xiazhang\go\src\github.com\kubernetes\utils>go test -v -race ./mount/...
=== RUN   TestDoCleanupMountPoint
=== RUN   TestDoCleanupMountPoint/mount-ok
=== RUN   TestDoCleanupMountPoint/mount-corrupted
=== RUN   TestDoCleanupMountPoint/mount-err-not-corrupted
--- PASS: TestDoCleanupMountPoint (0.01s)
    --- PASS: TestDoCleanupMountPoint/mount-ok (0.00s)
    --- PASS: TestDoCleanupMountPoint/mount-corrupted (0.00s)
    --- PASS: TestDoCleanupMountPoint/mount-err-not-corrupted (0.00s)
=== RUN   TestNormalizeWindowsPath
--- PASS: TestNormalizeWindowsPath (0.00s)
=== RUN   TestValidateDiskNumber
--- PASS: TestValidateDiskNumber (0.00s)
=== RUN   TestMakeBindOpts
--- PASS: TestMakeBindOpts (0.00s)
=== RUN   TestMakeBindOptsSensitive
--- PASS: TestMakeBindOptsSensitive (0.00s)
=== RUN   TestOptionsForLogging
--- PASS: TestOptionsForLogging (0.00s)
=== RUN   TestGetMountRefs
--- PASS: TestGetMountRefs (0.00s)
=== RUN   TestPathWithinBase
--- PASS: TestPathWithinBase (0.00s)
=== RUN   TestIsLikelyNotMountPoint
--- FAIL: TestIsLikelyNotMountPoint (0.02s)
    mount_windows_test.go:210: unexpected error in setUp(ValidSymLink, targetSymLink): mklink failed: exit status 1, link("C:\\Users\\xiazhang\\AppData\\Local\\Temp\\ValidSymLink852510010\\ValidSymLink") target("C:\\Users\\xiazhang\\AppData\\Local\\Temp\\ValidSymLink852510010\\targetSymLink") output: "You do not have sufficient privilege to perform this operation.\r\n"
=== RUN   TestFormatAndMount
E1015 15:43:35.068948   24208 mount_windows.go:241] diskMount: formatAndMount failed, err: wrong disk number format: "invalidDevice", err:strconv.Atoi: parsing "invalidDevice": invalid syntax
--- PASS: TestFormatAndMount (3.55s)
=== RUN   TestNewSMBMapping
--- PASS: TestNewSMBMapping (0.00s)
=== RUN   TestIsValidPath
--- PASS: TestIsValidPath (0.37s)
=== RUN   TestSafeFormatAndMount
--- SKIP: TestSafeFormatAndMount (0.00s)
    safe_format_and_mount_test.go:59: not supported on GOOS=windows
FAIL
FAIL    k8s.io/utils/mount      4.033s
FAIL
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
/assign @jingxu97 

**Release note**:
```
none
```
