### PR TITLE
net: add checks for isIPv4

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -137,6 +137,30 @@ func IsIPv6CIDR(cidr *net.IPNet) bool {
 	return IsIPv6(ip)
 }
 
+// IsIPv4 returns if netIP is IPv4.
+func IsIPv4(netIP net.IP) bool {
+	return netIP != nil && netIP.To4() != nil
+}
+
+// IsIPv4String returns if ip is IPv4.
+func IsIPv4String(ip string) bool {
+	netIP := net.ParseIP(ip)
+	return IsIPv4(netIP)
+}
+
+// IsIPv4CIDR returns if a cidr is ipv4
+func IsIPv4CIDR(cidr *net.IPNet) bool {
+	ip := cidr.IP
+	return IsIPv4(ip)
+}
+
+// IsIPv4CIDRString returns if cidr is IPv4.
+// This assumes cidr is a valid CIDR.
+func IsIPv4CIDRString(cidr string) bool {
+	ip, _, _ := net.ParseCIDR(cidr)
+	return IsIPv4(ip)
+}
+
 // ParsePort parses a string representing an IP port.  If the string is not a
 // valid port number, this returns an error.
 func ParsePort(port string, allowZero bool) (int, error) {

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -448,6 +448,185 @@ func TestIsIPv6CIDR(t *testing.T) {
 	}
 }
 
+func TestIsIPv4String(t *testing.T) {
+	testCases := []struct {
+		ip         string
+		expectIPv4 bool
+	}{
+		{
+			ip:         "127.0.0.1",
+			expectIPv4: true,
+		},
+		{
+			ip:         "192.168.0.0",
+			expectIPv4: true,
+		},
+		{
+			ip:         "1.2.3.4",
+			expectIPv4: true,
+		},
+		{
+			ip:         "bad ip",
+			expectIPv4: false,
+		},
+		{
+			ip:         "::1",
+			expectIPv4: false,
+		},
+		{
+			ip:         "fd00::600d:f00d",
+			expectIPv4: false,
+		},
+		{
+			ip:         "2001:db8::5",
+			expectIPv4: false,
+		},
+	}
+	for i := range testCases {
+		isIPv4 := IsIPv4String(testCases[i].ip)
+		if isIPv4 != testCases[i].expectIPv4 {
+			t.Errorf("[%d] Expect ipv4 %v, got %v", i+1, testCases[i].expectIPv4, isIPv4)
+		}
+	}
+}
+
+func TestIsIPv4(t *testing.T) {
+	testCases := []struct {
+		ip         net.IP
+		expectIPv4 bool
+	}{
+		{
+			ip:         net.IPv4zero,
+			expectIPv4: true,
+		},
+		{
+			ip:         net.IPv4bcast,
+			expectIPv4: true,
+		},
+		{
+			ip:         net.ParseIP("127.0.0.1"),
+			expectIPv4: true,
+		},
+		{
+			ip:         net.ParseIP("10.20.40.40"),
+			expectIPv4: true,
+		},
+		{
+			ip:         net.ParseIP("172.17.3.0"),
+			expectIPv4: true,
+		},
+		{
+			ip:         nil,
+			expectIPv4: false,
+		},
+		{
+			ip:         net.IPv6loopback,
+			expectIPv4: false,
+		},
+		{
+			ip:         net.IPv6zero,
+			expectIPv4: false,
+		},
+		{
+			ip:         net.ParseIP("fd00::600d:f00d"),
+			expectIPv4: false,
+		},
+		{
+			ip:         net.ParseIP("2001:db8::5"),
+			expectIPv4: false,
+		},
+	}
+	for i := range testCases {
+		isIPv4 := IsIPv4(testCases[i].ip)
+		if isIPv4 != testCases[i].expectIPv4 {
+			t.Errorf("[%d] Expect ipv4 %v, got %v", i+1, testCases[i].expectIPv4, isIPv4)
+		}
+	}
+}
+
+func TestIsIPv4CIDRString(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		cidr         string
+		expectResult bool
+	}{
+		{
+			desc:         "ipv4 CIDR 1",
+			cidr:         "10.0.0.0/8",
+			expectResult: true,
+		},
+		{
+			desc:         "ipv4 CIDR 2",
+			cidr:         "192.168.0.0/16",
+			expectResult: true,
+		},
+		{
+			desc:         "ipv6 CIDR 1",
+			cidr:         "::/1",
+			expectResult: false,
+		},
+		{
+			desc:         "ipv6 CIDR 2",
+			cidr:         "2000::/10",
+			expectResult: false,
+		},
+		{
+			desc:         "ipv6 CIDR 3",
+			cidr:         "2001:db8::/32",
+			expectResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		res := IsIPv4CIDRString(tc.cidr)
+		if res != tc.expectResult {
+			t.Errorf("%v: want IsIPv4CIDRString=%v, got %v", tc.desc, tc.expectResult, res)
+		}
+	}
+}
+
+func TestIsIPv4CIDR(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		cidr         string
+		expectResult bool
+	}{
+		{
+			desc:         "ipv4 CIDR 1",
+			cidr:         "10.0.0.0/8",
+			expectResult: true,
+		},
+		{
+			desc:         "ipv4 CIDR 2",
+			cidr:         "192.168.0.0/16",
+			expectResult: true,
+		},
+		{
+			desc:         "ipv6 CIDR 1",
+			cidr:         "::/1",
+			expectResult: false,
+		},
+		{
+			desc:         "ipv6 CIDR 2",
+			cidr:         "2000::/10",
+			expectResult: false,
+		},
+		{
+			desc:         "ipv6 CIDR 3",
+			cidr:         "2001:db8::/32",
+			expectResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, cidr, _ := net.ParseCIDR(tc.cidr)
+		res := IsIPv4CIDR(cidr)
+		if res != tc.expectResult {
+			t.Errorf("%v: want IsIPv4CIDR=%v, got %v", tc.desc, tc.expectResult, res)
+		}
+	}
+}
+
 func TestParsePort(t *testing.T) {
 	var tests = []struct {
 		name          string


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
These checks are basically a replication of the existing IPV4
checks. A similar method is used for IPv4 address checking in the
k8s/k8s dual_stack e2e testing. Adding these checks to k8s/util can cleanup a TODO mentioned in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/network/dual_stack.go#L528-L542 .

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:


**Release note**:
```
net: add checks for isIPv4
```
