### PR TITLE
Add NewTicker() to Clock

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -30,13 +30,36 @@ type PassiveClock interface {
 // needs to do arbitrary things based on time.
 type Clock interface {
 	PassiveClock
+	// After returns the channel of a new Timer.
+	// This method does not allow to free/GC the backing timer before it fires. Use
+	// NewTimer instead.
 	After(d time.Duration) <-chan time.Time
+	// NewTimer returns a new Timer.
 	NewTimer(d time.Duration) Timer
+	// Sleep sleeps for the provided duration d.
+	// Consider making the sleep interruptible by using 'select' on a context channel and a timer channel.
 	Sleep(d time.Duration)
+	// Tick returns the channel of a new Ticker.
+	// This method does not allow to free/GC the backing ticker. Use
+	// NewTicker from WithTicker instead.
 	Tick(d time.Duration) <-chan time.Time
 }
 
-var _ = Clock(RealClock{})
+// WithTicker allows for injecting fake or real clocks into code that
+// needs to do arbitrary things based on time.
+type WithTicker interface {
+	Clock
+	// NewTicker returns a new Ticker.
+	NewTicker(time.Duration) Ticker
+}
+
+// Ticker defines the Ticker interface.
+type Ticker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+var _ = WithTicker(RealClock{})
 
 // RealClock really calls time.Now()
 type RealClock struct{}
@@ -52,6 +75,8 @@ func (RealClock) Since(ts time.Time) time.Duration {
 }
 
 // After is the same as time.After(d).
+// This method does not allow to free/GC the backing timer before it fires. Use
+// NewTimer instead.
 func (RealClock) After(d time.Duration) <-chan time.Time {
 	return time.After(d)
 }
@@ -64,11 +89,21 @@ func (RealClock) NewTimer(d time.Duration) Timer {
 }
 
 // Tick is the same as time.Tick(d)
+// This method does not allow to free/GC the backing ticker. Use
+// NewTicker instead.
 func (RealClock) Tick(d time.Duration) <-chan time.Time {
 	return time.Tick(d)
 }
 
+// NewTicker returns a new Ticker.
+func (RealClock) NewTicker(d time.Duration) Ticker {
+	return &realTicker{
+		ticker: time.NewTicker(d),
+	}
+}
+
 // Sleep is the same as time.Sleep(d)
+// Consider making the sleep interruptible by using 'select' on a context channel and a timer channel.
 func (RealClock) Sleep(d time.Duration) {
 	time.Sleep(d)
 }
@@ -101,4 +136,16 @@ func (r *realTimer) Stop() bool {
 // Reset calls Reset() on the underlying timer.
 func (r *realTimer) Reset(d time.Duration) bool {
 	return r.timer.Reset(d)
+}
+
+type realTicker struct {
+	ticker *time.Ticker
+}
+
+func (r *realTicker) C() <-chan time.Time {
+	return r.ticker.C
+}
+
+func (r *realTicker) Stop() {
+	r.ticker.Stop()
 }

--- a/clock/testing/fake_clock.go
+++ b/clock/testing/fake_clock.go
@@ -25,8 +25,8 @@ import (
 
 var (
 	_ = clock.PassiveClock(&FakePassiveClock{})
-	_ = clock.Clock(&FakeClock{})
-	_ = clock.Clock(&IntervalClock{})
+	_ = clock.WithTicker(&FakeClock{})
+	_ = clock.WithTicker(&IntervalClock{})
 )
 
 // FakePassiveClock implements PassiveClock, but returns an arbitrary time.
@@ -135,6 +135,24 @@ func (f *FakeClock) Tick(d time.Duration) <-chan time.Time {
 	return ch
 }
 
+// NewTicker returns a new Ticker.
+func (f *FakeClock) NewTicker(d time.Duration) clock.Ticker {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	tickTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // hold one tick
+	f.waiters = append(f.waiters, &fakeClockWaiter{
+		targetTime:    tickTime,
+		stepInterval:  d,
+		skipIfBlocked: true,
+		destChan:      ch,
+	})
+
+	return &fakeTicker{
+		c: ch,
+	}
+}
+
 // Step moves the clock by Duration and notifies anyone that's called After,
 // Tick, or NewTimer.
 func (f *FakeClock) Step(d time.Duration) {
@@ -231,6 +249,12 @@ func (*IntervalClock) Tick(d time.Duration) <-chan time.Time {
 	panic("IntervalClock doesn't implement Tick")
 }
 
+// NewTicker is currently unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) NewTicker(d time.Duration) clock.Ticker {
+	panic("IntervalClock doesn't implement NewTicker")
+}
+
 // Sleep is unimplemented, will panic.
 func (*IntervalClock) Sleep(d time.Duration) {
 	panic("IntervalClock doesn't implement Sleep")
@@ -291,4 +315,15 @@ func (f *fakeTimer) Reset(d time.Duration) bool {
 	}
 
 	return active
+}
+
+type fakeTicker struct {
+	c <-chan time.Time
+}
+
+func (t *fakeTicker) C() <-chan time.Time {
+	return t.c
+}
+
+func (t *fakeTicker) Stop() {
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

See linked issues. TL;DR adds a missing method to allow safer usage and to bridge the gap between two copies of the clock package so that the one in apimachinery can be deleted.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes https://github.com/kubernetes/utils/issues/196.

Updates https://github.com/kubernetes/kubernetes/issues/94738.

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
