### PR TITLE
Pointer: simplify names, add *Equal() functions

### DIFF
--- a/pointer/pointer.go
+++ b/pointer/pointer.go
@@ -46,86 +46,182 @@ func AllPtrFieldsNil(obj interface{}) bool {
 	return true
 }
 
-// Int32Ptr returns a pointer to an int32
-func Int32Ptr(i int32) *int32 {
+// Int32 returns a pointer to an int32.
+func Int32(i int32) *int32 {
 	return &i
 }
 
-// Int32PtrDerefOr dereference the int32 ptr and returns it if not nil,
-// else returns def.
-func Int32PtrDerefOr(ptr *int32, def int32) int32 {
+var Int32Ptr = Int32 // for back-compat
+
+// Int32Deref dereferences the int32 ptr and returns it if not nil, or else
+// returns def.
+func Int32Deref(ptr *int32, def int32) int32 {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
 }
 
-// Int64Ptr returns a pointer to an int64
-func Int64Ptr(i int64) *int64 {
+var Int32PtrDerefOr = Int32Deref // for back-compat
+
+// Int32Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Int32Equal(a, b *int32) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// Int64 returns a pointer to an int64.
+func Int64(i int64) *int64 {
 	return &i
 }
 
-// Int64PtrDerefOr dereference the int64 ptr and returns it if not nil,
-// else returns def.
-func Int64PtrDerefOr(ptr *int64, def int64) int64 {
+var Int64Ptr = Int64 // for back-compat
+
+// Int64Deref dereferences the int64 ptr and returns it if not nil, or else
+// returns def.
+func Int64Deref(ptr *int64, def int64) int64 {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
 }
 
-// BoolPtr returns a pointer to a bool
-func BoolPtr(b bool) *bool {
+var Int64PtrDerefOr = Int64Deref // for back-compat
+
+// Int64Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Int64Equal(a, b *int64) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// Bool returns a pointer to a bool.
+func Bool(b bool) *bool {
 	return &b
 }
 
-// BoolPtrDerefOr dereference the bool ptr and returns it if not nil,
-// else returns def.
-func BoolPtrDerefOr(ptr *bool, def bool) bool {
+var BoolPtr = Bool // for back-compat
+
+// BoolDeref dereferences the bool ptr and returns it if not nil, or else
+// returns def.
+func BoolDeref(ptr *bool, def bool) bool {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
 }
 
-// StringPtr returns a pointer to the passed string.
-func StringPtr(s string) *string {
+var BoolPtrDerefOr = BoolDeref // for back-compat
+
+// BoolEqual returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func BoolEqual(a, b *bool) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// String returns a pointer to a string.
+func String(s string) *string {
 	return &s
 }
 
-// StringPtrDerefOr dereference the string ptr and returns it if not nil,
-// else returns def.
-func StringPtrDerefOr(ptr *string, def string) string {
+var StringPtr = String // for back-compat
+
+// StringDeref dereferences the string ptr and returns it if not nil, or else
+// returns def.
+func StringDeref(ptr *string, def string) string {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
 }
 
-// Float32Ptr returns a pointer to the passed float32.
-func Float32Ptr(i float32) *float32 {
+var StringPtrDerefOr = StringDeref // for back-compat
+
+// StringEqual returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func StringEqual(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// Float32 returns a pointer to the a float32.
+func Float32(i float32) *float32 {
 	return &i
 }
 
-// Float32PtrDerefOr dereference the float32 ptr and returns it if not nil,
-// else returns def.
-func Float32PtrDerefOr(ptr *float32, def float32) float32 {
+var Float32Ptr = Float32
+
+// Float32Deref dereferences the float32 ptr and returns it if not nil, or else
+// returns def.
+func Float32Deref(ptr *float32, def float32) float32 {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
 }
 
-// Float64Ptr returns a pointer to the passed float64.
-func Float64Ptr(i float64) *float64 {
+var Float32PtrDerefOr = Float32Deref // for back-compat
+
+// Float32Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Float32Equal(a, b *float32) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// Float64 returns a pointer to the a float64.
+func Float64(i float64) *float64 {
 	return &i
 }
 
-// Float64PtrDerefOr dereference the float64 ptr and returns it if not nil,
-// else returns def.
-func Float64PtrDerefOr(ptr *float64, def float64) float64 {
+var Float64Ptr = Float64
+
+// Float64Deref dereferences the float64 ptr and returns it if not nil, or else
+// returns def.
+func Float64Deref(ptr *float64, def float64) float64 {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
+}
+
+var Float64PtrDerefOr = Float64Deref // for back-compat
+
+// Float64Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Float64Equal(a, b *float64) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
 }

--- a/pointer/pointer_test.go
+++ b/pointer/pointer_test.go
@@ -69,170 +69,278 @@ func TestAllPtrFieldsNil(t *testing.T) {
 	}
 }
 
-func TestInt32Ptr(t *testing.T) {
+func TestInt32(t *testing.T) {
 	val := int32(0)
-	ptr := Int32Ptr(val)
+	ptr := Int32(val)
 	if *ptr != val {
 		t.Errorf("expected %d, got %d", val, *ptr)
 	}
 
 	val = int32(1)
-	ptr = Int32Ptr(val)
+	ptr = Int32(val)
 	if *ptr != val {
 		t.Errorf("expected %d, got %d", val, *ptr)
 	}
 }
 
-func TestInt32PtrDerefOr(t *testing.T) {
+func TestInt32Deref(t *testing.T) {
 	var val, def int32 = 1, 0
 
-	out := Int32PtrDerefOr(&val, def)
+	out := Int32Deref(&val, def)
 	if out != val {
 		t.Errorf("expected %d, got %d", val, out)
 	}
 
-	out = Int32PtrDerefOr(nil, def)
+	out = Int32Deref(nil, def)
 	if out != def {
 		t.Errorf("expected %d, got %d", def, out)
 	}
 }
 
-func TestInt64Ptr(t *testing.T) {
+func TestInt32Equal(t *testing.T) {
+	if !Int32Equal(nil, nil) {
+		t.Errorf("expected true (nil == nil)")
+	}
+	if !Int32Equal(Int32(123), Int32(123)) {
+		t.Errorf("expected true (val == val)")
+	}
+	if Int32Equal(nil, Int32(123)) {
+		t.Errorf("expected false (nil != val)")
+	}
+	if Int32Equal(Int32(123), nil) {
+		t.Errorf("expected false (val != nil)")
+	}
+	if Int32Equal(Int32(123), Int32(456)) {
+		t.Errorf("expected false (val != val)")
+	}
+}
+
+func TestInt64(t *testing.T) {
 	val := int64(0)
-	ptr := Int64Ptr(val)
+	ptr := Int64(val)
 	if *ptr != val {
 		t.Errorf("expected %d, got %d", val, *ptr)
 	}
 
 	val = int64(1)
-	ptr = Int64Ptr(val)
+	ptr = Int64(val)
 	if *ptr != val {
 		t.Errorf("expected %d, got %d", val, *ptr)
 	}
 }
 
-func TestInt64PtrDerefOr(t *testing.T) {
+func TestInt64Deref(t *testing.T) {
 	var val, def int64 = 1, 0
 
-	out := Int64PtrDerefOr(&val, def)
+	out := Int64Deref(&val, def)
 	if out != val {
 		t.Errorf("expected %d, got %d", val, out)
 	}
 
-	out = Int64PtrDerefOr(nil, def)
+	out = Int64Deref(nil, def)
 	if out != def {
 		t.Errorf("expected %d, got %d", def, out)
 	}
 }
 
-func TestBoolPtr(t *testing.T) {
+func TestInt64Equal(t *testing.T) {
+	if !Int64Equal(nil, nil) {
+		t.Errorf("expected true (nil == nil)")
+	}
+	if !Int64Equal(Int64(123), Int64(123)) {
+		t.Errorf("expected true (val == val)")
+	}
+	if Int64Equal(nil, Int64(123)) {
+		t.Errorf("expected false (nil != val)")
+	}
+	if Int64Equal(Int64(123), nil) {
+		t.Errorf("expected false (val != nil)")
+	}
+	if Int64Equal(Int64(123), Int64(456)) {
+		t.Errorf("expected false (val != val)")
+	}
+}
+
+func TestBool(t *testing.T) {
 	val := false
-	ptr := BoolPtr(val)
+	ptr := Bool(val)
 	if *ptr != val {
 		t.Errorf("expected %t, got %t", val, *ptr)
 	}
 
 	val = true
-	ptr = BoolPtr(true)
+	ptr = Bool(true)
 	if *ptr != val {
 		t.Errorf("expected %t, got %t", val, *ptr)
 	}
 }
 
-func TestBoolPtrDerefOr(t *testing.T) {
+func TestBoolDeref(t *testing.T) {
 	val, def := true, false
 
-	out := BoolPtrDerefOr(&val, def)
+	out := BoolDeref(&val, def)
 	if out != val {
 		t.Errorf("expected %t, got %t", val, out)
 	}
 
-	out = BoolPtrDerefOr(nil, def)
+	out = BoolDeref(nil, def)
 	if out != def {
 		t.Errorf("expected %t, got %t", def, out)
 	}
 }
 
-func TestStringPtr(t *testing.T) {
+func TestBoolEqual(t *testing.T) {
+	if !BoolEqual(nil, nil) {
+		t.Errorf("expected true (nil == nil)")
+	}
+	if !BoolEqual(Bool(true), Bool(true)) {
+		t.Errorf("expected true (val == val)")
+	}
+	if BoolEqual(nil, Bool(true)) {
+		t.Errorf("expected false (nil != val)")
+	}
+	if BoolEqual(Bool(true), nil) {
+		t.Errorf("expected false (val != nil)")
+	}
+	if BoolEqual(Bool(true), Bool(false)) {
+		t.Errorf("expected false (val != val)")
+	}
+}
+
+func TestString(t *testing.T) {
 	val := ""
-	ptr := StringPtr(val)
+	ptr := String(val)
 	if *ptr != val {
 		t.Errorf("expected %s, got %s", val, *ptr)
 	}
 
 	val = "a"
-	ptr = StringPtr(val)
+	ptr = String(val)
 	if *ptr != val {
 		t.Errorf("expected %s, got %s", val, *ptr)
 	}
 }
 
-func TestStringPtrDerefOr(t *testing.T) {
+func TestStringDeref(t *testing.T) {
 	val, def := "a", ""
 
-	out := StringPtrDerefOr(&val, def)
+	out := StringDeref(&val, def)
 	if out != val {
 		t.Errorf("expected %s, got %s", val, out)
 	}
 
-	out = StringPtrDerefOr(nil, def)
+	out = StringDeref(nil, def)
 	if out != def {
 		t.Errorf("expected %s, got %s", def, out)
 	}
 }
 
-func TestFloat32Ptr(t *testing.T) {
+func TestStringEqual(t *testing.T) {
+	if !StringEqual(nil, nil) {
+		t.Errorf("expected true (nil == nil)")
+	}
+	if !StringEqual(String("abc"), String("abc")) {
+		t.Errorf("expected true (val == val)")
+	}
+	if StringEqual(nil, String("abc")) {
+		t.Errorf("expected false (nil != val)")
+	}
+	if StringEqual(String("abc"), nil) {
+		t.Errorf("expected false (val != nil)")
+	}
+	if StringEqual(String("abc"), String("def")) {
+		t.Errorf("expected false (val != val)")
+	}
+}
+
+func TestFloat32(t *testing.T) {
 	val := float32(0)
-	ptr := Float32Ptr(val)
+	ptr := Float32(val)
 	if *ptr != val {
 		t.Errorf("expected %f, got %f", val, *ptr)
 	}
 
 	val = float32(0.1)
-	ptr = Float32Ptr(val)
+	ptr = Float32(val)
 	if *ptr != val {
 		t.Errorf("expected %f, got %f", val, *ptr)
 	}
 }
 
-func TestFloat32PtrDerefOr(t *testing.T) {
+func TestFloat32Deref(t *testing.T) {
 	var val, def float32 = 0.1, 0
 
-	out := Float32PtrDerefOr(&val, def)
+	out := Float32Deref(&val, def)
 	if out != val {
 		t.Errorf("expected %f, got %f", val, out)
 	}
 
-	out = Float32PtrDerefOr(nil, def)
+	out = Float32Deref(nil, def)
 	if out != def {
 		t.Errorf("expected %f, got %f", def, out)
 	}
 }
 
-func TestFloat64Ptr(t *testing.T) {
+func TestFloat32Equal(t *testing.T) {
+	if !Float32Equal(nil, nil) {
+		t.Errorf("expected true (nil == nil)")
+	}
+	if !Float32Equal(Float32(1.25), Float32(1.25)) {
+		t.Errorf("expected true (val == val)")
+	}
+	if Float32Equal(nil, Float32(1.25)) {
+		t.Errorf("expected false (nil != val)")
+	}
+	if Float32Equal(Float32(1.25), nil) {
+		t.Errorf("expected false (val != nil)")
+	}
+	if Float32Equal(Float32(1.25), Float32(4.5)) {
+		t.Errorf("expected false (val != val)")
+	}
+}
+
+func TestFloat64(t *testing.T) {
 	val := float64(0)
-	ptr := Float64Ptr(val)
+	ptr := Float64(val)
 	if *ptr != val {
 		t.Errorf("expected %f, got %f", val, *ptr)
 	}
 
 	val = float64(0.1)
-	ptr = Float64Ptr(val)
+	ptr = Float64(val)
 	if *ptr != val {
 		t.Errorf("expected %f, got %f", val, *ptr)
 	}
 }
 
-func TestFloat64PtrDerefOr(t *testing.T) {
+func TestFloat64Deref(t *testing.T) {
 	var val, def float64 = 0.1, 0
 
-	out := Float64PtrDerefOr(&val, def)
+	out := Float64Deref(&val, def)
 	if out != val {
 		t.Errorf("expected %f, got %f", val, out)
 	}
 
-	out = Float64PtrDerefOr(nil, def)
+	out = Float64Deref(nil, def)
 	if out != def {
 		t.Errorf("expected %f, got %f", def, out)
+	}
+}
+
+func TestFloat64Equal(t *testing.T) {
+	if !Float64Equal(nil, nil) {
+		t.Errorf("expected true (nil == nil)")
+	}
+	if !Float64Equal(Float64(1.25), Float64(1.25)) {
+		t.Errorf("expected true (val == val)")
+	}
+	if Float64Equal(nil, Float64(1.25)) {
+		t.Errorf("expected false (nil != val)")
+	}
+	if Float64Equal(Float64(1.25), nil) {
+		t.Errorf("expected false (val != nil)")
+	}
+	if Float64Equal(Float64(1.25), Float64(4.5)) {
+		t.Errorf("expected false (val != val)")
 	}
 }


### PR DESCRIPTION
I keep reviewing logic which open-codes the comparison of 2 pointers.


/kind cleanup
/kind feature

**Release note**:
```
pointer: Renamed "new" functions to simpler names (old names kept for compat), e.g. StringPtr() -> String().
pointer: Renamed "deref" functions to simpler names (old names kept for compat), e.g. DerefStringPtrOr() -> DerefString().
pointer: Added new equality testers, e.g pointer.StringEqual().
```
