### PR TITLE
Add explicit error to ConsistentRead

### DIFF
--- a/io/read_test.go
+++ b/io/read_test.go
@@ -89,8 +89,12 @@ func TestConsistentReadFlakyReader(t *testing.T) {
 	prog, done := make(chan int), make(chan bool)
 	go writer(pipe, true, prog, done)
 
-	if _, err := consistentReadSync(pipe, 3, func(i int) { prog <- i }); err == nil {
+	var err error
+	if _, err = consistentReadSync(pipe, 3, func(i int) { prog <- i }); err == nil {
 		t.Fatal("flaky reader returned consistent results")
+	}
+	if !IsInconsistentReadError(err) {
+		t.Errorf("Unexpected error returned, expected InconsistentReadError, got: %T / %q", err, err)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Return a specific error when `ConsistentRead` fails because it cannot get a consistent content on given file to give caller an opportunity to make better decision what to do about it.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Helps to work around https://github.com/kubernetes/kubernetes/issues/101791
Prerequisite of https://github.com/kubernetes/kubernetes/pull/102059

**Release note**:
```
ConsistentRead now returns distinct error code when it cannot get a consistent read of a file.
```
