### PR TITLE
Add string slice functions

### DIFF
--- a/strings/slices/slices.go
+++ b/strings/slices/slices.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package slices defines various functions useful with slices of string type.
+// The goal is to be as close as possible to
+// https://github.com/golang/go/issues/45955. Ideal would be if we can just
+// replace "stringslices" if the "slices" package becomes standard.
+package slices
+
+// Equal reports whether two slices are equal: the same length and all
+// elements equal. If the lengths are different, Equal returns false.
+// Otherwise, the elements are compared in index order, and the
+// comparison stops at the first unequal pair.
+func Equal(s1, s2 []string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i, n := range s1 {
+		if n != s2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Filter appends to d each element e of s for which keep(e) returns true.
+// It returns the modified d. d may be s[:0], in which case the kept
+// elements will be stored in the same slice.
+// if the slices overlap in some other way, the results are unspecified.
+// To create a new slice with the filtered results, pass nil for d.
+func Filter(d, s []string, keep func(string) bool) []string {
+	for _, n := range s {
+		if keep(n) {
+			d = append(d, n)
+		}
+	}
+	return d
+}
+
+// Contains reports whether v is present in s.
+func Contains(s []string, v string) bool {
+	return Index(s, v) >= 0
+}
+
+// Index returns the index of the first occurrence of v in s, or -1 if
+// not present.
+func Index(s []string, v string) int {
+	// "Contains" may be replaced with "Index(s, v) >= 0":
+	// https://github.com/golang/go/issues/45955#issuecomment-873377947
+	for i, n := range s {
+		if n == v {
+			return i
+		}
+	}
+	return -1
+}
+
+// Functions below are not in https://github.com/golang/go/issues/45955
+
+// Clone returns a new clone of s.
+func Clone(s []string) []string {
+	// https://github.com/go101/go101/wiki/There-is-not-a-perfect-way-to-clone-slices-in-Go
+	if s == nil {
+		return nil
+	}
+	c := make([]string, len(s))
+	copy(c, s)
+	return c
+}

--- a/strings/slices/slices_test.go
+++ b/strings/slices/slices_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slices
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	utilnet "k8s.io/utils/net"
+)
+
+func Example() {
+	a := []string{
+		"10.0.0.0", "FOO", "1000::1", "fd80::4%eth0", "BAR", "192.168.1.300",
+		"172.12.0.1", "fc00::5000",
+	}
+	v := func(s string) bool { return net.ParseIP(s) == nil }
+	if notIP := Filter(nil, a, v); len(notIP) > 0 {
+		fmt.Println("Invalid", notIP)
+	}
+	fmt.Println(Filter(nil, a, utilnet.IsIPv6String))
+	// Output:
+	// Invalid [FOO fd80::4%eth0 BAR 192.168.1.300]
+	// [1000::1 fc00::5000]
+}
+
+func Example_regexp() {
+	a := []string{
+		"10.0.0.0", "FOO", "1000::1", "fd80::4%eth0", "BAR", "192.168.1.300",
+		"172.12.0.1", "fc00::5000",
+	}
+	re := regexp.MustCompile("^[A-Z]+$")
+	fmt.Println(Filter(nil, a, re.MatchString))
+	// Output: [FOO BAR]
+}
+
+func ExampleFilter_empty() {
+	s := []string{"FOO", "", "", "BAR", "fd80::8888", ""}
+	fmt.Println(Filter(nil, s, func(s string) bool { return s != "" }))
+	// Output: [FOO BAR fd80::8888]
+}
+
+func TestFilter(t *testing.T) {
+	testCases := []struct {
+		validator func(string) bool
+		input     []string
+		res       []string
+	}{
+		// Filter all
+		{
+			regexp.MustCompile("zzz.*").MatchString,
+			[]string{"FOO", "1000::", "BAR", "fd80::8888"},
+			nil,
+		},
+		// Filter none
+		{
+			regexp.MustCompile(".*").MatchString,
+			[]string{"FOO", "1000::", "BAR", "fd80::8888"},
+			[]string{"FOO", "1000::", "BAR", "fd80::8888"},
+		},
+		// Filter some
+		{
+			func(s string) bool { return strings.Contains(s, ".") },
+			[]string{"10.0.0.0", "1000::", "8.8.8.8", "fd80::8888"},
+			[]string{"10.0.0.0", "8.8.8.8"},
+		},
+	}
+	for i, tc := range testCases {
+		res := Filter(nil, tc.input, tc.validator)
+		if !reflect.DeepEqual(tc.res, res) {
+			t.Errorf("TC %d: %v expected %v", i, res, tc.res)
+		}
+	}
+}
+
+func TestFilterInplace(t *testing.T) {
+	testCases := []struct {
+		validator  func(string) bool
+		input      []string
+		res        []string
+		inputAfter []string
+	}{
+		// Filter all
+		{
+			func(s string) bool { return s != "" },
+			[]string{"FOO", "", "", "BAR", "fd80::8888", ""},
+			[]string{"FOO", "BAR", "fd80::8888"},
+			[]string{"FOO", "BAR", "fd80::8888", "BAR", "fd80::8888", ""},
+		},
+	}
+	for i, tc := range testCases {
+		res := Filter(tc.input[:0], tc.input, tc.validator)
+		if !reflect.DeepEqual(tc.res, res) {
+			t.Errorf("TC %d: %v expected %v", i, res, tc.res)
+		}
+		if !reflect.DeepEqual(tc.input, tc.inputAfter) {
+			t.Errorf("TC %d: mutated input %v expected %v", i, tc.input, tc.inputAfter)
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	testCases := []struct {
+		input []string
+		what  string
+		res   bool
+	}{
+		// Contains special case
+		{
+			nil,
+			"",
+			false,
+		},
+		// Contains
+		{
+			[]string{"FOO", "BAR", ""},
+			"",
+			true,
+		},
+		// Not Contains
+		{
+			[]string{"FOO", "BAR", ""},
+			"NOPE",
+			false,
+		},
+	}
+	for i, tc := range testCases {
+		res := Contains(tc.input, tc.what)
+		if res != tc.res {
+			t.Errorf("TC %d: %v expected %v", i, res, tc.res)
+		}
+	}
+}
+
+func TestClone(t *testing.T) {
+	testCases := []struct {
+		input []string
+		res   []string
+	}{
+		{
+			nil,
+			nil,
+		},
+		{
+			[]string{},
+			[]string{},
+		},
+		{
+			[]string{"", "FOO", "BAR", ""},
+			[]string{"", "FOO", "BAR", ""},
+		},
+	}
+	for i, tc := range testCases {
+		res := Clone(tc.input)
+		if !reflect.DeepEqual(tc.res, res) {
+			t.Errorf("TC %d: %v expected %v", i, res, tc.res)
+		}
+		if len(tc.input) > 0 {
+			tc.input[0] = "NOPE"
+			if tc.res[0] == "NOPE" {
+				t.Errorf("TC %d: Clone is not cloned", i)
+			}
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Part of https://github.com/kubernetes/kubernetes/issues/92369. The first goal is to replace `k8s.io/kubernetes/pkg/util/slice/`.

The lack of a simple []string filter function has spawned quite weird specialized help functions in K8s. Use of these functions (and later the go "slices" package) will improve code maintainability.

Usage example:
```go
func Example() {
	a := []string{
		"10.0.0.0", "FOO", "1000::1", "fd80::4%eth0", "BAR", "192.168.1.300",
		"172.12.0.1", "fc00::5000",
	}
	v := func(s string) bool { return net.ParseIP(s) == nil }
	if notIP := Filter(nil, a, v); len(notIP) > 0 {
		fmt.Println("Invalid", notIP)
	}
	fmt.Println(Filter(nil, a, utilnet.IsIPv6String))
	// Output:
	// Invalid [FOO fd80::4%eth0 BAR 192.168.1.300]
	// [1000::1 fc00::5000]
}
```


**Which issue(s) this PR fixes**:

Part of https://github.com/kubernetes/kubernetes/issues/92369

**Special notes for your reviewer**:

There is an open issue to add a "slices" package to go: https://github.com/golang/go/issues/45955

The intention is to keep this implementation as close to the go slices proposal as possible. Ideal is if the proposal becomes a go standard package all applications need to do is to replcace "stringslices" -> "slices"

Related to https://github.com/kubernetes/utils/pull/202.

View generated doc:
```
cd /your/cloned/k8s.io/utils/
godoc -goroot .
firefox -new-window http://localhost:6060/pkg/k8s.io/utils/strings/
```

**Release note**:
```
NONE
```
