### PR TITLE
Introduce WithTicker clock

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -30,13 +30,36 @@ type PassiveClock interface {
 // needs to do arbitrary things based on time.
 type Clock interface {
 	PassiveClock
+	// After returns the channel of a new Timer.
+	// This method does not allow to free/GC the backing timer before it fires. Use
+	// NewTimer instead.
 	After(d time.Duration) <-chan time.Time
+	// NewTimer returns a new Timer.
 	NewTimer(d time.Duration) Timer
+	// Sleep sleeps for the provided duration d.
+	// Consider making the sleep interruptible by using 'select' on a context channel and a timer channel.
 	Sleep(d time.Duration)
+	// Tick returns the channel of a new Ticker.
+	// This method does not allow to free/GC the backing ticker. Use
+	// NewTicker from WithTicker instead.
 	Tick(d time.Duration) <-chan time.Time
 }
 
-var _ = Clock(RealClock{})
+// WithTicker allows for injecting fake or real clocks into code that
+// needs to do arbitrary things based on time.
+type WithTicker interface {
+	Clock
+	// NewTicker returns a new Ticker.
+	NewTicker(time.Duration) Ticker
+}
+
+// Ticker defines the Ticker interface.
+type Ticker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+var _ = WithTicker(RealClock{})
 
 // RealClock really calls time.Now()
 type RealClock struct{}
@@ -52,6 +75,8 @@ func (RealClock) Since(ts time.Time) time.Duration {
 }
 
 // After is the same as time.After(d).
+// This method does not allow to free/GC the backing timer before it fires. Use
+// NewTimer instead.
 func (RealClock) After(d time.Duration) <-chan time.Time {
 	return time.After(d)
 }
@@ -64,11 +89,21 @@ func (RealClock) NewTimer(d time.Duration) Timer {
 }
 
 // Tick is the same as time.Tick(d)
+// This method does not allow to free/GC the backing ticker. Use
+// NewTicker instead.
 func (RealClock) Tick(d time.Duration) <-chan time.Time {
 	return time.Tick(d)
 }
 
+// NewTicker returns a new Ticker.
+func (RealClock) NewTicker(d time.Duration) Ticker {
+	return &realTicker{
+		ticker: time.NewTicker(d),
+	}
+}
+
 // Sleep is the same as time.Sleep(d)
+// Consider making the sleep interruptible by using 'select' on a context channel and a timer channel.
 func (RealClock) Sleep(d time.Duration) {
 	time.Sleep(d)
 }
@@ -101,4 +136,16 @@ func (r *realTimer) Stop() bool {
 // Reset calls Reset() on the underlying timer.
 func (r *realTimer) Reset(d time.Duration) bool {
 	return r.timer.Reset(d)
+}
+
+type realTicker struct {
+	ticker *time.Ticker
+}
+
+func (r *realTicker) C() <-chan time.Time {
+	return r.ticker.C
+}
+
+func (r *realTicker) Stop() {
+	r.ticker.Stop()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
See linked issues. TL;DR adds a missing method to allow safer usage and to bridge the gap between two copies of the clock package so that the one in apimachinery can be deleted.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #196

Updates kubernetes/kubernetes#94738

**Special notes for your reviewer**:
This is an alternative to #197 and is almost identical.  The only difference is that I have removed `IntervalClock::NewTicker` because its implementation just panics, so it is misleading to make IntervalClock appear to implement WithTicker.


**Release note**:
```
NONE
```
