### PR TITLE
Introduced SimpleIntervalClock

### DIFF
--- a/clock/testing/fake_clock.go
+++ b/clock/testing/fake_clock.go
@@ -196,7 +196,9 @@ func (f *FakeClock) Sleep(d time.Duration) {
 	f.Step(d)
 }
 
-// IntervalClock implements clock.Clock, but each invocation of Now steps the clock forward the specified duration
+// IntervalClock implements clock.PassiveClock, but each invocation of Now steps the clock forward the specified duration.
+// IntervalClock technically implements the other methods of clock.Clock, but each implementation is just a panic.
+// See SimpleIntervalClock for an alternative that only has the methods of PassiveClock.
 type IntervalClock struct {
 	Time     time.Time
 	Duration time.Duration

--- a/clock/testing/simple_interval_clock.go
+++ b/clock/testing/simple_interval_clock.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+var (
+	_ = clock.PassiveClock(&SimpleIntervalClock{})
+)
+
+// SimpleIntervalClock implements clock.PassiveClock, but each invocation of Now steps the clock forward the specified duration
+type SimpleIntervalClock struct {
+	Time     time.Time
+	Duration time.Duration
+}
+
+// Now returns i's time.
+func (i *SimpleIntervalClock) Now() time.Time {
+	i.Time = i.Time.Add(i.Duration)
+	return i.Time
+}
+
+// Since returns time since the time in i.
+func (i *SimpleIntervalClock) Since(ts time.Time) time.Duration {
+	return i.Time.Sub(ts)
+}


### PR DESCRIPTION
This is a more honest alternative to IntervalClock.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR introduces clock/testing.SimpleIntervalClock, which is a better alternative to clock/testing.IntervalClock because the latter has additional methods that just panic.  Using the former makes for checking at compile time while the latter does the corresponding checking at runtime.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
See https://github.com/kubernetes/utils/pull/197#discussion_r674361869 for the start of the discussion leading here.

**Release note**:
```
NONE
```
