### PR TITLE
lru: use read/write lock for lru get

### DIFF
--- a/lru/lru.go
+++ b/lru/lru.go
@@ -45,8 +45,8 @@ func (c *Cache) Add(key Key, value interface{}) {
 
 // Get looks up a key's value from the cache.
 func (c *Cache) Get(key Key) (value interface{}, ok bool) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.cache.Get(key)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`Get` is mutating since it moves an element to the front when it's accessed, using a read-only lock can result in a panic like the below:

```
2021-08-18T19:57:56.080933580Z E0818 19:57:56.080795      17 runtime.go:78] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(0x4ad36a0), concrete:(*runtime._type)(nil), asserted:(*runtime._
type)(0x4769e60), missingMethod:""} (interface conversion: interface {} is nil, not *golang_lru.entry)
2021-08-18T19:57:56.080933580Z goroutine 5333 [running]:
2021-08-18T19:57:56.080933580Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x4c78f00, 0xc0398de210)
2021-08-18T19:57:56.080933580Z  /go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x95
2021-08-18T19:57:56.080933580Z k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
2021-08-18T19:57:56.080933580Z  /go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x86
2021-08-18T19:57:56.080933580Z panic(0x4c78f00, 0xc0398de210)
2021-08-18T19:57:56.080933580Z  /usr/lib/golang/src/runtime/panic.go:965 +0x1b9
2021-08-18T19:57:56.080933580Z k8s.io/kubernetes/vendor/k8s.io/utils/internal/third_party/forked/golang/golang-lru.(*Cache).removeElement(0xc00012b280, 0xc0013afef0)
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/104452


