### PR TITLE
keymutex: simplify unlocking

### DIFF
--- a/keymutex/hashed.go
+++ b/keymutex/hashed.go
@@ -41,8 +41,11 @@ type hashedKeyMutex struct {
 }
 
 // Acquires a lock associated with the specified ID.
-func (km *hashedKeyMutex) LockKey(id string) {
+func (km *hashedKeyMutex) LockKey(id string) func() {
 	km.mutexes[km.hash(id)%uint32(len(km.mutexes))].Lock()
+	return func() {
+		km.UnlockKey(id)
+	}
 }
 
 // Releases the lock associated with the specified ID.

--- a/keymutex/keymutex.go
+++ b/keymutex/keymutex.go
@@ -18,8 +18,8 @@ package keymutex
 
 // KeyMutex is a thread-safe interface for acquiring locks on arbitrary strings.
 type KeyMutex interface {
-	// Acquires a lock associated with the specified ID, creates the lock if one doesn't already exist.
-	LockKey(id string)
+	// Acquires a lock associated with the specified ID, creates the lock if one doesn't already exist. The function that it returns can be used to unlock.
+	LockKey(id string) func()
 
 	// Releases the lock associated with the specified ID.
 	// Returns an error if the specified ID doesn't exist.


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change

**What this PR does / why we need it**:

The common pattern is:
```
  mutex.LockKey(key)
  defer mutex.UnlockKey(key)
```
However, linters point out the the error return of UnlockKey is not checked.
It is possible and okay to suppress that because it is known that the right key
is getting passed into that function:
```
  mutex.LockKey(key)
  defer func() {
     _ = mutex.UnlockKey(key)
  }()
```

But this is rather ugly. By returning an unlock function, locking and unlocking
can be done in a single line with less code:
```
  defer mutex.LockKey(key)()
```

**Special notes for your reviewer**:

Strictly speaking, this is an API break because it changes the LockKey signature. But in practice, existing code continues to compile and work as intended.

**Release note**:
```
simpler keymutex: locking and unlocking in a single line
```
