### PR TITLE
fix: read small files or files that show zero size once as a large file.

### DIFF
--- a/io/read.go
+++ b/io/read.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 )
 
 // ErrLimitReached means that the read limit is reached.
@@ -41,6 +42,23 @@ func ConsistentRead(filename string, attempts int) ([]byte, error) {
 // introduces a sync callback that can be used by the tests to mutate the file
 // from which the test data is being read
 func consistentReadSync(filename string, attempts int, sync func(int)) ([]byte, error) {
+
+	// get the size of the file.
+	size, err := getFileSize(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	// if the size of the file is less than 512 bytes, assume that reading from
+	// /proc or /sys like cases for Linux.
+	if size < 512 {
+		if contents, err := consistentReadFileNoStat(filename); err == nil {
+			return contents, nil
+		}
+		// fall back to consistent read because this is now a utility and an error here can break
+		// expected behavior.
+	}
+
 	oldContent, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -60,6 +78,52 @@ func consistentReadSync(filename string, attempts int, sync func(int)) ([]byte, 
 		oldContent = newContent
 	}
 	return nil, InconsistentReadError{filename, attempts}
+}
+
+// get filesize returns the filesize
+func getFileSize(filename string) (int, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return 0, err
+	}
+
+	var size int
+	// Calling stat should be okay as it supports both Windows and Linux
+	// Ref (unix and posix compliant): https://cs.opensource.google/go/go/+/refs/tags/go1.17.1:src/os/stat_unix.go;l=16
+	// Ref (windows): https://cs.opensource.google/go/go/+/refs/tags/go1.17.1:src/os/stat_windows.go
+	if info, err := f.Stat(); err == nil {
+		size64 := info.Size()
+		if int64(int(size64)) == size64 {
+			size = int(size64)
+		}
+	}
+	size++ // one byte for final read at EOF
+	return size, nil
+}
+
+// consistentReadFileNoStat is inspired from prometheus code base for /proc and /sys
+func consistentReadFileNoStat(filename string) ([]byte, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+
+	const maxBufferSize = 1024 * 512
+	var contents = make([]byte, maxBufferSize)
+
+	// use f.Read as it points to File.Read which will directly call os dependent functions
+	// For Linux: https://cs.opensource.google/go/go/+/master:src/syscall/syscall_unix.go;l=188;bpv=1;bpt=1?q=syscall.Read&ss=go%2Fgo
+	// Also, do not prefer ReadAtMost as it internally results in a loop for read depending on the buffer capacity.
+	// This will result in multiple syscall.Read
+	n, err := f.Read(contents)
+	if err != nil {
+		// not returning contents to ensure that the bytes are not used up the stack as they occupy memory.
+		return []byte{}, err
+	}
+	// slice the byte before returning to the x number of bytes so that the maximum buffer is not reached
+	return contents[:n], nil
 }
 
 // InconsistentReadError is returned from ConsistentRead when it cannot get


### PR DESCRIPTION
/proc/mounts zero as disk usage size

```
ubuntu@ip-172-31-49-2:~/go/src/k8s.io/kubernetes/vendor/k8s.io/utils/io$
du -h /proc/mounts
0	/proc/mounts
ubuntu@ip-172-31-49-2:~/go/src/k8s.io/kubernetes/vendor/k8s.io/utils/io$
```

As a result of which between multiple read calls, the content of
/proc/mounts might change, this change introduceces reading 0 or small
files to read the entire file in 1 go.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Reduces the occurrence of https://github.com/kubernetes/kubernetes/issues/104976

When multiple pods with many subpaths are trying to mount / umount the subPaths, then the /proc/mounts keeps on consistently changing. To avoid this scenario, we should read the entire `/proc/mounts` in one go and also not do consistentRead check.

This PR introduces the change in the consistentRead to demonstrate the change and gather feedback from the community.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #  https://github.com/kubernetes/kubernetes/issues/104976

**Special notes for your reviewer**:

* This is to gather feedback and we can change the code specific to subPath itself.
* Should we introduce unix specific build tags in the utils library.
* Should we extract this out to a separate function itself in subPath rather than rely on this library
* Tested this change with steps given in: https://github.com/kubernetes/kubernetes/issues/104976 for a 1.5 hours; at 150 pods per 5 min. I have not seen any issue so far.

**Release note**:
```
N/A
```

/sig storage 

