### PR TITLE
Prepare clock package to be compatible replacement of apimachinery/util/clock

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -63,6 +63,16 @@ type WithDelayedExecution interface {
 	AfterFunc(d time.Duration, f func()) Timer
 }
 
+// WithTickerAndDelayedExecution allows for injecting fake or real clocks
+// into code that needs Ticker and AfterFunc functionality
+type WithTickerAndDelayedExecution interface {
+	WithTicker
+	// AfterFunc executes f in its own goroutine after waiting
+	// for d duration and returns a Timer whose channel can be
+	// closed by calling Stop() on the Timer.
+	AfterFunc(d time.Duration, f func()) Timer
+}
+
 // Ticker defines the Ticker interface.
 type Ticker interface {
 	C() <-chan time.Time

--- a/clock/testing/fake_clock.go
+++ b/clock/testing/fake_clock.go
@@ -282,9 +282,9 @@ func (*IntervalClock) Tick(d time.Duration) <-chan time.Time {
 
 // NewTicker has no implementation yet and is omitted.
 // TODO: make interval clock use FakeClock so this can be implemented.
-//func (*IntervalClock) NewTicker(d time.Duration) clock.Ticker {
-//	panic("IntervalClock doesn't implement NewTicker")
-//}
+func (*IntervalClock) NewTicker(d time.Duration) clock.Ticker {
+	panic("IntervalClock doesn't implement NewTicker")
+}
 
 // Sleep is unimplemented, will panic.
 func (*IntervalClock) Sleep(d time.Duration) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
**What this PR does / why we need it**:
Commit 1:
The reason for doing this is that `utils/clock` is supposed
to be a full replacement for `k8s.io/apimachinery/pkg/util/clock`.

Currently, `WithDelayedExecution` extends Clock - in order to deprecate
apimachinery/clock, `WithDelayedExecution` would be missing the NewTicker
method if gradual deprecation via type aliasing was to be done.

By extending `WithTicker` instead of `Clock`, we solve this issue.

Commit 2:
Eventhough the implementation is just a panic,
re-implementing the `NewTicker` method helps
in migration of the apimachinery/util/clock pkg
to the utils/clock pkg in terms of having identical
clients for `IntervalClock` in both packages as
well as the `IntervalClock` implementing the
`WithTickerAndDelayedExcution` interface.

**Which issue(s) this PR fixes**:
Related to https://github.com/kubernetes/kubernetes/issues/94738

**Special notes for your reviewer**:
The next step after this would be to implement the `Tick` method in apimachinery clock, type aliasing the interfaces and marking the package as deprecated.

**Release note**:
```
NONE
```
/assign @liggitt @dims 
/cc @wojtek-t 
