### PR TITLE
fix panic error cause by index out of range when people use multi thr…

### DIFF
--- a/buffer/ring_growing.go
+++ b/buffer/ring_growing.go
@@ -28,10 +28,10 @@ type RingGrowing struct {
 }
 
 // NewRingGrowing constructs a new RingGrowing instance with provided parameters.
-func NewRingGrowing(initialSize int32) *RingGrowing {
+func NewRingGrowing(initialSize int) *RingGrowing {
 	return &RingGrowing{
 		data: make([]interface{}, initialSize),
-		n:    initialSize,
+		n:    int32(initialSize),
 	}
 }
 

--- a/buffer/ring_growing_test.go
+++ b/buffer/ring_growing_test.go
@@ -27,7 +27,7 @@ func TestGrowth(t *testing.T) {
 	x := 10
 	g := NewRingGrowing(1)
 	for i := 0; i < x; i++ {
-		assert.Equal(t, i, g.readable)
+		assert.Equal(t, int32(i), g.readable)
 		g.WriteOne(i)
 	}
 	read := 0
@@ -39,7 +39,7 @@ func TestGrowth(t *testing.T) {
 	}
 	assert.Equalf(t, x, read, "expected to have read %d items: %d", x, read)
 	assert.Zerof(t, g.readable, "expected readable to be zero: %d", g.readable)
-	assert.Equalf(t, 16, g.n, "expected N to be 16: %d", g.n)
+	assert.Equalf(t, int32(16), g.n, "expected N to be 16: %d", g.n)
 }
 
 func TestEmpty(t *testing.T) {


### PR DESCRIPTION
…eading reading

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/106003

**Special notes for your reviewer**:


**Release note**:
```

```
