### PR TITLE
fix inotify memory leak

### DIFF
--- a/inotify/inotify_linux.go
+++ b/inotify/inotify_linux.go
@@ -120,7 +120,11 @@ func (w *Watcher) RemoveWatch(path string) error {
 	}
 	success, errno := syscall.InotifyRmWatch(w.fd, watch.wd)
 	if success == -1 {
-		return os.NewSyscallError("inotify_rm_watch", errno)
+		// when file descriptor or watch descriptor not found, InotifyRmWatch syscall return EINVAL error
+		// if return error, it may lead this path remain in watches and paths map, and no other event can trigger remove action.
+		if errno != syscall.EINVAL {
+			return os.NewSyscallError("inotify_rm_watch", errno)
+		}
 	}
 	delete(w.watches, path)
 	// Locking here to protect the read from paths in readEvents.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:

when delete file or dir , os will delete watch descriptor related to this path, file descriptor or watch descriptor not found, InotifyRmWatch syscall return EINVAL error, if return error, it may lead this path remain in watches and paths map, and no other event can trigger remove action. 

**Which issue(s) this PR fixes**:


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#100241](https://github.com/kubernetes/kubernetes/issues/100241)

**Special notes for your reviewer**:


**Release note**:
```

```
