### PR TITLE
clock: Add test coverage for SimpleIntervalClock

### DIFF
--- a/clock/testing/simple_interval_clock_test.go
+++ b/clock/testing/simple_interval_clock_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSimpleIntervalClockNow(t *testing.T) {
+	cases := []struct {
+		duration time.Duration
+	}{
+		{duration: 10 * time.Millisecond},
+		{duration: 0 * time.Millisecond},
+		{duration: -10 * time.Millisecond},
+	}
+
+	startTime := time.Now()
+	for _, c := range cases {
+		expectedTime := startTime.Add(c.duration)
+		sic := &SimpleIntervalClock{
+			Time:     startTime,
+			Duration: c.duration,
+		}
+		actualTime := sic.Now()
+		if !expectedTime.Equal(actualTime) {
+			t.Errorf("expected %#v, got %#v", expectedTime, actualTime)
+		}
+	}
+}
+
+func TestSimpleIntervalClockSince(t *testing.T) {
+	cases := []struct {
+		delta time.Duration
+	}{
+		{delta: 10 * time.Millisecond},
+		{delta: 0 * time.Millisecond},
+		{delta: -10 * time.Millisecond},
+	}
+
+	startTime := time.Now()
+	duration := time.Millisecond
+	sic := &SimpleIntervalClock{
+		Time:     startTime,
+		Duration: duration,
+	}
+
+	for _, c := range cases {
+		// Try and add compute a "since" time by
+		// Add()ing a -c.delta.
+		timeSinceDelta := startTime.Add(-c.delta)
+		expectedDelta := sic.Since(timeSinceDelta)
+		if expectedDelta != c.delta {
+			t.Errorf("expected %#v, got %#v", expectedDelta, c.delta)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds test coverage for `SimpleIntervalClock`

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
NA

**Special notes for your reviewer**:
NA

**Release note**:
```
NONE
```
/assign @MikeSpreitzer @dims 