### PR TITLE
pointer: Add helper funcs for time.Duration

### DIFF
--- a/pointer/pointer.go
+++ b/pointer/pointer.go
@@ -19,6 +19,7 @@ package pointer
 import (
 	"fmt"
 	"reflect"
+	"time"
 )
 
 // AllPtrFieldsNil tests whether all pointer fields in a struct are nil.  This is useful when,
@@ -184,7 +185,7 @@ func StringEqual(a, b *string) bool {
 	return *a == *b
 }
 
-// Float32 returns a pointer to the a float32.
+// Float32 returns a pointer to a float32.
 func Float32(i float32) *float32 {
 	return &i
 }
@@ -214,7 +215,7 @@ func Float32Equal(a, b *float32) bool {
 	return *a == *b
 }
 
-// Float64 returns a pointer to the a float64.
+// Float64 returns a pointer to a float64.
 func Float64(i float64) *float64 {
 	return &i
 }
@@ -235,6 +236,32 @@ var Float64PtrDerefOr = Float64Deref // for back-compat
 // Float64Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
 func Float64Equal(a, b *float64) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// Duration returns a pointer to a time.Duration.
+func Duration(d time.Duration) *time.Duration {
+	return &d
+}
+
+// DurationDeref dereferences the time.Duration ptr and returns it if not nil, or else
+// returns def.
+func DurationDeref(ptr *time.Duration, def time.Duration) time.Duration {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
+// DurationEqual returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func DurationEqual(a, b *time.Duration) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}

--- a/pointer/pointer_test.go
+++ b/pointer/pointer_test.go
@@ -19,6 +19,7 @@ package pointer
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestAllPtrFieldsNil(t *testing.T) {
@@ -369,6 +370,52 @@ func TestFloat64Equal(t *testing.T) {
 		t.Errorf("expected false (val != nil)")
 	}
 	if Float64Equal(Float64(1.25), Float64(4.5)) {
+		t.Errorf("expected false (val != val)")
+	}
+}
+
+func TestDuration(t *testing.T) {
+	val := time.Duration(0)
+	ptr := Duration(val)
+	if *ptr != val {
+		t.Errorf("expected %s, got %s", val, *ptr)
+	}
+
+	val = time.Duration(42)
+	ptr = Duration(val)
+	if *ptr != val {
+		t.Errorf("expected %s, got %s", val, *ptr)
+	}
+}
+
+func TestDurationDeref(t *testing.T) {
+	var val, def time.Duration = 42, 0
+
+	out := DurationDeref(&val, def)
+	if out != val {
+		t.Errorf("expected %s, got %s", val, out)
+	}
+
+	out = DurationDeref(nil, def)
+	if out != def {
+		t.Errorf("expected %s, got %s", def, out)
+	}
+}
+
+func TestDurationEqual(t *testing.T) {
+	if !DurationEqual(nil, nil) {
+		t.Errorf("expected true (nil == nil)")
+	}
+	if !DurationEqual(Duration(42), Duration(42)) {
+		t.Errorf("expected true (val == val)")
+	}
+	if DurationEqual(nil, Duration(42)) {
+		t.Errorf("expected false (nil != val)")
+	}
+	if DurationEqual(Duration(42), nil) {
+		t.Errorf("expected false (val != nil)")
+	}
+	if DurationEqual(Duration(42), Duration(43)) {
 		t.Errorf("expected false (val != val)")
 	}
 }


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
The PR adds helper funcs to the pointer pkg for working with `time.Duration`.


**Release note**:
```
NONE
```
