### PR TITLE
IPv6 was not of IPFamily type

### DIFF
--- a/net/port.go
+++ b/net/port.go
@@ -28,7 +28,8 @@ type IPFamily string
 
 // Constants for valid IPFamilys:
 const (
-	IPv4, IPv6 IPFamily = "4", "6"
+	IPv4 IPFamily = "4"
+	IPv6 IPFamily = "6"
 )
 
 // Protocol is a network protocol support by LocalPort.

--- a/net/port.go
+++ b/net/port.go
@@ -28,8 +28,7 @@ type IPFamily string
 
 // Constants for valid IPFamilys:
 const (
-	IPv4 IPFamily = "4"
-	IPv6          = "6"
+	IPv4, IPv6 IPFamily = "4", "6"
 )
 
 // Protocol is a network protocol support by LocalPort.


### PR DESCRIPTION
See https://goplay.tools/snippet/xzIT8x5I_EZ for example.

There was a floating untyped string.  Should not impact much but safer to type enforce.

/kind bug
/kind cleanup
