### PR TITLE
Ineffective break statements triggering SA4011

### DIFF
--- a/mount/mount.go
+++ b/mount/mount.go
@@ -290,9 +290,7 @@ func MakeBindOptsSensitive(options []string, sensitiveOptions []string) (bool, [
 		switch option {
 		case "bind":
 			bind = true
-			break
-		case "remount":
-			break
+		case "remount": // Do nothing.
 		default:
 			bindRemountOpts = append(bindRemountOpts, option)
 		}
@@ -302,9 +300,7 @@ func MakeBindOptsSensitive(options []string, sensitiveOptions []string) (bool, [
 		switch sensitiveOption {
 		case "bind":
 			bind = true
-			break
-		case "remount":
-			break
+		case "remount": // Do nothing.
 		default:
 			bindRemountSensitiveOpts = append(bindRemountSensitiveOpts, sensitiveOption)
 		}


### PR DESCRIPTION
These trigger https://staticcheck.io/docs/checks#SA4011

I am assuming we do not run static checks in CI but this one is a little dangerous because breaks are commonly misused to indicate breaking from the outer loop. Here it seems we just want to skip. I added "Do Nothing" to be explicit.

/kind cleanup


**Special notes for your reviewer**:


**Release note**:
```

```
