### PR TITLE
add uint64 and uint to pointer pkg

### DIFF
--- a/pointer/pointer.go
+++ b/pointer/pointer.go
@@ -103,6 +103,62 @@ func Int32Equal(a, b *int32) bool {
 	return *a == *b
 }
 
+// Uint returns a pointer to an uint
+func Uint(i uint) *uint {
+	return &i
+}
+
+// UintPtr is a function variable referring to Uint.
+// Deprecated: Use Uint instead.
+var UintPtr = Uint // for back-compat
+
+// UintDeref dereferences the uint ptr and returns it if not nil, or else
+// returns def.
+func UintDeref(ptr *uint, def uint) uint {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
+// UintPtrDerefOr is a function variable referring to UintDeref.
+// Deprecated: Use UintDeref instead.
+var UintPtrDerefOr = UintDeref // for back-compat
+
+// Uint32 returns a pointer to an uint32.
+func Uint32(i uint32) *uint32 {
+	return &i
+}
+
+// Uint32Ptr is a function variable referring to Uint32.
+// Deprecated: Use Uint32 instead.
+var Uint32Ptr = Uint32 // for back-compat
+
+// Uint32Deref dereferences the uint32 ptr and returns it if not nil, or else
+// returns def.
+func Uint32Deref(ptr *uint32, def uint32) uint32 {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
+// Uint32PtrDerefOr is a function variable referring to Uint32Deref.
+// Deprecated: Use Uint32Deref instead.
+var Uint32PtrDerefOr = Uint32Deref // for back-compat
+
+// Uint32Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Uint32Equal(a, b *uint32) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
 // Int64 returns a pointer to an int64.
 func Int64(i int64) *int64 {
 	return &i
@@ -128,6 +184,40 @@ var Int64PtrDerefOr = Int64Deref // for back-compat
 // Int64Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
 func Int64Equal(a, b *int64) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// Uint64 returns a pointer to an uint64.
+func Uint64(i uint64) *uint64 {
+	return &i
+}
+
+// Uint64Ptr is a function variable referring to Uint64.
+// Deprecated: Use Uint64 instead.
+var Uint64Ptr = Uint64 // for back-compat
+
+// Uint64Deref dereferences the uint64 ptr and returns it if not nil, or else
+// returns def.
+func Uint64Deref(ptr *uint64, def uint64) uint64 {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
+// Uint64PtrDerefOr is a function variable referring to Uint64Deref.
+// Deprecated: Use Uint64Deref instead.
+var Uint64PtrDerefOr = Uint64Deref // for back-compat
+
+// Uint64Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Uint64Equal(a, b *uint64) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}

--- a/pointer/pointer_test.go
+++ b/pointer/pointer_test.go
@@ -144,6 +144,80 @@ func TestInt32Equal(t *testing.T) {
 	}
 }
 
+func TestUint(t *testing.T) {
+	val := uint(0)
+	ptr := Uint(val)
+	if *ptr != val {
+		t.Errorf("expected %d, got %d", val, *ptr)
+	}
+
+	val = uint(1)
+	ptr = Uint(val)
+	if *ptr != val {
+		t.Errorf("expected %d, got %d", val, *ptr)
+	}
+}
+
+func TestUintDeref(t *testing.T) {
+	var val, def uint = 1, 0
+
+	out := UintDeref(&val, def)
+	if out != val {
+		t.Errorf("expected %d, got %d", val, out)
+	}
+
+	out = UintDeref(nil, def)
+	if out != def {
+		t.Errorf("expected %d, got %d", def, out)
+	}
+}
+
+func TestUint32(t *testing.T) {
+	val := uint32(0)
+	ptr := Uint32(val)
+	if *ptr != val {
+		t.Errorf("expected %d, got %d", val, *ptr)
+	}
+
+	val = uint32(1)
+	ptr = Uint32(val)
+	if *ptr != val {
+		t.Errorf("expected %d, got %d", val, *ptr)
+	}
+}
+
+func TestUint32Deref(t *testing.T) {
+	var val, def uint32 = 1, 0
+
+	out := Uint32Deref(&val, def)
+	if out != val {
+		t.Errorf("expected %d, got %d", val, out)
+	}
+
+	out = Uint32Deref(nil, def)
+	if out != def {
+		t.Errorf("expected %d, got %d", def, out)
+	}
+}
+
+func TestUint32Equal(t *testing.T) {
+	if !Uint32Equal(nil, nil) {
+		t.Errorf("expected true (nil == nil)")
+	}
+	if !Uint32Equal(Uint32(123), Uint32(123)) {
+		t.Errorf("expected true (val == val)")
+	}
+	if Uint32Equal(nil, Uint32(123)) {
+		t.Errorf("expected false (nil != val)")
+	}
+	if Uint32Equal(Uint32(123), nil) {
+		t.Errorf("expected false (val != nil)")
+	}
+	if Uint32Equal(Uint32(123), Uint32(456)) {
+		t.Errorf("expected false (val != val)")
+	}
+}
+
 func TestInt64(t *testing.T) {
 	val := int64(0)
 	ptr := Int64(val)
@@ -186,6 +260,52 @@ func TestInt64Equal(t *testing.T) {
 		t.Errorf("expected false (val != nil)")
 	}
 	if Int64Equal(Int64(123), Int64(456)) {
+		t.Errorf("expected false (val != val)")
+	}
+}
+
+func TestUint64(t *testing.T) {
+	val := uint64(0)
+	ptr := Uint64(val)
+	if *ptr != val {
+		t.Errorf("expected %d, got %d", val, *ptr)
+	}
+
+	val = uint64(1)
+	ptr = Uint64(val)
+	if *ptr != val {
+		t.Errorf("expected %d, got %d", val, *ptr)
+	}
+}
+
+func TestUint64Deref(t *testing.T) {
+	var val, def uint64 = 1, 0
+
+	out := Uint64Deref(&val, def)
+	if out != val {
+		t.Errorf("expected %d, got %d", val, out)
+	}
+
+	out = Uint64Deref(nil, def)
+	if out != def {
+		t.Errorf("expected %d, got %d", def, out)
+	}
+}
+
+func TestUint64Equal(t *testing.T) {
+	if !Uint64Equal(nil, nil) {
+		t.Errorf("expected true (nil == nil)")
+	}
+	if !Uint64Equal(Uint64(123), Uint64(123)) {
+		t.Errorf("expected true (val == val)")
+	}
+	if Uint64Equal(nil, Uint64(123)) {
+		t.Errorf("expected false (nil != val)")
+	}
+	if Uint64Equal(Uint64(123), nil) {
+		t.Errorf("expected false (val != nil)")
+	}
+	if Uint64Equal(Uint64(123), Uint64(456)) {
 		t.Errorf("expected false (val != val)")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds support for interacting with 32 and 64bit unsigned ints in the `pointer` package.
We wanted to standardize on the pointer package but found that it was lacking unsigned int support which is commonly used in k8s and applications interacting with k8s. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I'm not 100% sure if it makes sense to add the back-compatibility pieces which I copied from the existing `Int`and `Int64` implementations. If not I can back them out and just leave the new pieces.

**Release note**:
```

```
