### PR TITLE
Fix an API accident with net.IPFamily

### DIFF
--- a/net/port.go
+++ b/net/port.go
@@ -29,7 +29,7 @@ type IPFamily string
 // Constants for valid IPFamilys:
 const (
 	IPv4 IPFamily = "4"
-	IPv6          = "6"
+	IPv6 IPFamily = "6"
 )
 
 // Protocol is a network protocol support by LocalPort.


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change
/kind cleanup

**What this PR does / why we need it**:
`net.IPv4` had type `net.IPFamily`, but `net.IPv6` was an untyped string. This is obviously wrong. Fortunately it would have been difficult for anyone to use this constant in a way that would break by fixing this (given that almost all users of `net.IPv6` would be using it along with `net.IPv4` and thus would be using it in a context where it would have to have been promoted from untyped string to `net.IPFamily` anyway). (Also, AFAIK no one is using this code anyway.) (But I want to use the type for something else, so I want to fix it.)

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
I originally fixed this as a drive-by in #234 which ended up never getting merged because it needed API review which it never got. Trying to split out just the allegedly-controversial part.

**Release note**:
```
Fixed a bug in the `net` package where the constant `net.IPv6` had the wrong type.
This is technically an API break but is extremely unlikely to actually break anyone.
```

/sig network