### PR TITLE
pointer: make deprecation comments follow convention

### DIFF
--- a/pointer/pointer.go
+++ b/pointer/pointer.go
@@ -53,6 +53,7 @@ func Int(i int) *int {
 }
 
 // IntPtr is a function variable referring to Int.
+//
 // Deprecated: Use Int instead.
 var IntPtr = Int // for back-compat
 
@@ -66,6 +67,7 @@ func IntDeref(ptr *int, def int) int {
 }
 
 // IntPtrDerefOr is a function variable referring to IntDeref.
+//
 // Deprecated: Use IntDeref instead.
 var IntPtrDerefOr = IntDeref // for back-compat
 
@@ -75,6 +77,7 @@ func Int32(i int32) *int32 {
 }
 
 // Int32Ptr is a function variable referring to Int32.
+//
 // Deprecated: Use Int32 instead.
 var Int32Ptr = Int32 // for back-compat
 
@@ -88,6 +91,7 @@ func Int32Deref(ptr *int32, def int32) int32 {
 }
 
 // Int32PtrDerefOr is a function variable referring to Int32Deref.
+//
 // Deprecated: Use Int32Deref instead.
 var Int32PtrDerefOr = Int32Deref // for back-compat
 
@@ -109,6 +113,7 @@ func Uint(i uint) *uint {
 }
 
 // UintPtr is a function variable referring to Uint.
+//
 // Deprecated: Use Uint instead.
 var UintPtr = Uint // for back-compat
 
@@ -122,6 +127,7 @@ func UintDeref(ptr *uint, def uint) uint {
 }
 
 // UintPtrDerefOr is a function variable referring to UintDeref.
+//
 // Deprecated: Use UintDeref instead.
 var UintPtrDerefOr = UintDeref // for back-compat
 
@@ -131,6 +137,7 @@ func Uint32(i uint32) *uint32 {
 }
 
 // Uint32Ptr is a function variable referring to Uint32.
+//
 // Deprecated: Use Uint32 instead.
 var Uint32Ptr = Uint32 // for back-compat
 
@@ -144,6 +151,7 @@ func Uint32Deref(ptr *uint32, def uint32) uint32 {
 }
 
 // Uint32PtrDerefOr is a function variable referring to Uint32Deref.
+//
 // Deprecated: Use Uint32Deref instead.
 var Uint32PtrDerefOr = Uint32Deref // for back-compat
 
@@ -165,6 +173,7 @@ func Int64(i int64) *int64 {
 }
 
 // Int64Ptr is a function variable referring to Int64.
+//
 // Deprecated: Use Int64 instead.
 var Int64Ptr = Int64 // for back-compat
 
@@ -178,6 +187,7 @@ func Int64Deref(ptr *int64, def int64) int64 {
 }
 
 // Int64PtrDerefOr is a function variable referring to Int64Deref.
+//
 // Deprecated: Use Int64Deref instead.
 var Int64PtrDerefOr = Int64Deref // for back-compat
 
@@ -199,6 +209,7 @@ func Uint64(i uint64) *uint64 {
 }
 
 // Uint64Ptr is a function variable referring to Uint64.
+//
 // Deprecated: Use Uint64 instead.
 var Uint64Ptr = Uint64 // for back-compat
 
@@ -212,6 +223,7 @@ func Uint64Deref(ptr *uint64, def uint64) uint64 {
 }
 
 // Uint64PtrDerefOr is a function variable referring to Uint64Deref.
+//
 // Deprecated: Use Uint64Deref instead.
 var Uint64PtrDerefOr = Uint64Deref // for back-compat
 
@@ -233,6 +245,7 @@ func Bool(b bool) *bool {
 }
 
 // BoolPtr is a function variable referring to Bool.
+//
 // Deprecated: Use Bool instead.
 var BoolPtr = Bool // for back-compat
 
@@ -246,6 +259,7 @@ func BoolDeref(ptr *bool, def bool) bool {
 }
 
 // BoolPtrDerefOr is a function variable referring to BoolDeref.
+//
 // Deprecated: Use BoolDeref instead.
 var BoolPtrDerefOr = BoolDeref // for back-compat
 
@@ -267,6 +281,7 @@ func String(s string) *string {
 }
 
 // StringPtr is a function variable referring to String.
+//
 // Deprecated: Use String instead.
 var StringPtr = String // for back-compat
 
@@ -280,6 +295,7 @@ func StringDeref(ptr *string, def string) string {
 }
 
 // StringPtrDerefOr is a function variable referring to StringDeref.
+//
 // Deprecated: Use StringDeref instead.
 var StringPtrDerefOr = StringDeref // for back-compat
 
@@ -301,6 +317,7 @@ func Float32(i float32) *float32 {
 }
 
 // Float32Ptr is a function variable referring to Float32.
+//
 // Deprecated: Use Float32 instead.
 var Float32Ptr = Float32
 
@@ -314,6 +331,7 @@ func Float32Deref(ptr *float32, def float32) float32 {
 }
 
 // Float32PtrDerefOr is a function variable referring to Float32Deref.
+//
 // Deprecated: Use Float32Deref instead.
 var Float32PtrDerefOr = Float32Deref // for back-compat
 
@@ -335,6 +353,7 @@ func Float64(i float64) *float64 {
 }
 
 // Float64Ptr is a function variable referring to Float64.
+//
 // Deprecated: Use Float64 instead.
 var Float64Ptr = Float64
 
@@ -348,6 +367,7 @@ func Float64Deref(ptr *float64, def float64) float64 {
 }
 
 // Float64PtrDerefOr is a function variable referring to Float64Deref.
+//
 // Deprecated: Use Float64Deref instead.
 var Float64PtrDerefOr = Float64Deref // for back-compat
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
https://github.com/golang/go/wiki/Deprecated says the `Deprecated:` bit
should start a paragraph, not just a line. Some linters, including the
widely used golangci-lint, do not see the deprecation notices that do
not follow the convention, and then people miss the opportunity to fix
up their code:

```console
❯ cat main.go
package main

import (
  "fmt"
  "k8s.io/utils/pointer"
)

func main() {
  truthy := pointer.BoolPtr(true)
  fmt.Printf("pointer.BoolPtr: %t\n", *truthy)
}
❯ staticcheck ./...
❯ sed -i 's|// Deprecated:|//\n// Deprecated:|' vendor/k8s.io/utils/pointer/pointer.go
❯ staticcheck ./...
main.go:9:13: pointer.BoolPtr is deprecated: Use Bool instead.  (SA1019)
```

**Special notes for your reviewer**:
The intent of https://github.com/kubernetes/utils/pull/249 was to make the linters warn, so even this dummy change should be useful.

**Release note**:
```
NONE
```
