### PR TITLE
Fix trace panic when concurrently adding children

### DIFF
--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -628,13 +628,12 @@ func TestParentEndedBeforeChild(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		go func(parent *Trace) {
 			child := parent.Nest("bar")
-			child.Step("ding")
+			child.Step("hello")
 			child.LogIfLong(0 * time.Second)
 		}(parent)
 	}
-	parent.Step("ding")
+	parent.Step("world")
 	parent.LogIfLong(0 * time.Second)
-	time.Sleep(1 * time.Millisecond)
 }
 
 func TestContext(t *testing.T) {

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -621,6 +621,22 @@ func TestStepThreshold(t *testing.T) {
 	}
 }
 
+func TestParentEndedBeforeChild(t *testing.T) {
+	var buf bytes.Buffer
+	klog.SetOutput(&buf)
+	parent := New("foo")
+	for i := 0; i < 1000; i++ {
+		go func(parent *Trace) {
+			child := parent.Nest("bar")
+			child.Step("ding")
+			child.LogIfLong(0 * time.Second)
+		}(parent)
+	}
+	parent.Step("ding")
+	parent.LogIfLong(0 * time.Second)
+	time.Sleep(1 * time.Millisecond)
+}
+
 func TestContext(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Attempts to fix a panic found in integration tests.  The panics were introduced after nested traces were introduced in https://github.com/kubernetes/kubernetes/pull/113172.

This adds a test which easily caused a panic without the locking.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/113651

**Release note**:
```
NONE
```

cc @liggitt @aojea @logicalhan 