### PR TITLE
Fix fsnotify util upstream link and suggest newer version.

### DIFF
--- a/inotify/README.md
+++ b/inotify/README.md
@@ -1,5 +1,5 @@
 This is a fork of golang.org/x/exp/inotify before it was deleted.
 
-Please use gopkg.in/fsnotify.v0 instead.
+Please use gopkg.in/fsnotify.v1 instead.
 
-For updates, see: https://fsnotify.org/
+For updates, see: https://github.com/fsnotify/fsnotify


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

The fsnotify.org domain no longer belongs to the project, we should just refer to the github repository instead.

Additionally a newer version of fsnotify package `gopkg.in/fsnotify.v1` has been released (2018), we should possibly be suggesting that instead of the old (2015) `v0`?


**Which issue(s) this PR fixes**:
Fixes #240

**Special notes for your reviewer**:

Is this util even still required? How can we check if it is still being consumed?


