### PR TITLE
Add Uint64 version of RangeSize

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -70,15 +70,23 @@ func AddIPOffset(base *big.Int, offset int) net.IP {
 // RangeSize returns the size of a range in valid addresses.
 // returns the size of the subnet (or math.MaxInt64 if the range size would overflow int64)
 func RangeSize(subnet *net.IPNet) int64 {
-	ones, bits := subnet.Mask.Size()
-	if bits == 32 && (bits-ones) >= 31 || bits == 128 && (bits-ones) >= 127 {
-		return 0
-	}
+	size := RangeSizeU64(subnet)
 	// this checks that we are not overflowing an int64
-	if bits-ones >= 63 {
+	if size >= math.MaxInt64 {
 		return math.MaxInt64
 	}
-	return int64(1) << uint(bits-ones)
+	return int64(size)
+}
+
+// RangeSizeU64 returns the size of a range in valid addresses.
+// returns the size of the subnet (or math.MaxInt64 if the range size would overflow int64)
+func RangeSizeU64(subnet *net.IPNet) uint64 {
+	ones, bits := subnet.Mask.Size()
+	// this checks that we are not overflowing an uint64
+	if bits-ones >= 64 {
+		return math.MaxUint64
+	}
+	return uint64(1) << uint(bits-ones)
 }
 
 // GetIndexedIP returns a net.IP that is subnet.IP + index in the contiguous IP space.

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package net
 
 import (
+	"math"
 	"testing"
 )
 
@@ -140,24 +141,76 @@ func TestParsePort(t *testing.T) {
 
 func TestRangeSize(t *testing.T) {
 	testCases := []struct {
-		name  string
-		cidr  string
-		addrs int64
+		name     string
+		cidr     string
+		addrs    int64
+		addrsU64 uint64
 	}{
 		{
-			name:  "supported IPv4 cidr",
-			cidr:  "192.168.1.0/24",
-			addrs: 256,
+			name:     "supported IPv4 cidr",
+			cidr:     "192.168.1.0/24",
+			addrs:    256,
+			addrsU64: 256,
 		},
 		{
-			name:  "unsupported IPv4 cidr",
-			cidr:  "192.168.1.0/1",
-			addrs: 0,
+			name:     "single IPv4 host",
+			cidr:     "192.168.1.0/32",
+			addrs:    1,
+			addrsU64: 1,
 		},
 		{
-			name:  "unsupported IPv6 mask",
-			cidr:  "2001:db8::/1",
-			addrs: 0,
+			name:     "small IPv4 cidr",
+			cidr:     "192.168.1.0/31",
+			addrs:    2,
+			addrsU64: 2,
+		},
+		{
+			name:     "very large IPv4 cidr",
+			cidr:     "0.0.0.0/1",
+			addrs:    math.MaxInt32 + 1,
+			addrsU64: math.MaxInt32 + 1,
+		},
+		{
+			name:     "full IPv4 range",
+			cidr:     "0.0.0.0/0",
+			addrs:    math.MaxUint32 + 1,
+			addrsU64: math.MaxUint32 + 1,
+		},
+		{
+			name:     "supported IPv6 cidr",
+			cidr:     "2001:db2::/112",
+			addrs:    65536,
+			addrsU64: 65536,
+		},
+		{
+			name:     "single IPv6 host",
+			cidr:     "2001:db8::/128",
+			addrs:    1,
+			addrsU64: 1,
+		},
+		{
+			name:     "small IPv6 cidr",
+			cidr:     "2001:db8::/127",
+			addrs:    2,
+			addrsU64: 2,
+		},
+		{
+			name:     "largest IPv6 for Int64",
+			cidr:     "2001:db8::/65",
+			addrs:    math.MaxInt64,
+			addrsU64: math.MaxInt64 + 1,
+		},
+		{
+			name:     "largest IPv6 for Uint64",
+			cidr:     "2001:db8::/64",
+			addrs:    math.MaxInt64,
+			addrsU64: math.MaxUint64,
+		},
+		{
+			name:     "very large IPv6 cidr",
+			cidr:     "2001:db8::/1",
+			addrs:    math.MaxInt64,
+			addrsU64: math.MaxUint64,
 		},
 	}
 
@@ -169,6 +222,10 @@ func TestRangeSize(t *testing.T) {
 		if size := RangeSize(cidr); size != tc.addrs {
 			t.Errorf("test %s failed. %s should have a range size of %d, got %d",
 				tc.name, tc.cidr, tc.addrs, size)
+		}
+		if size := RangeSizeU64(cidr); size != tc.addrsU64 {
+			t.Errorf("test %s failed. %s should have a range size of %d, got %d",
+				tc.name, tc.cidr, tc.addrsU64, size)
 		}
 	}
 }


### PR DESCRIPTION
The goal is to support /64 ranges in kubernetes, so we need to use unsigned integers to avoid capping the range.

It also removes the "strange" capping of /1 and /0 cidrs.

/kind bug
/kind cleanup

Spotted by @danwinship in https://github.com/kubernetes/kubernetes/pull/115075/commits/f35fb15be32671edf47e32eb1fb528b0564eccc9#r1096110657


```
NONE
```
