### PR TITLE
add generic methods for integer package

### DIFF
--- a/integer/integer.go
+++ b/integer/integer.go
@@ -16,7 +16,29 @@ limitations under the License.
 
 package integer
 
+// number is a constraint that permits any signed type, or any unsigned type
+type number interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+// Max returns the maximum of the params
+func Max[E number](a, b E) E {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+// Min returns the minimum of the params
+func Min[E number](a, b E) E {
+	if b < a {
+		return b
+	}
+	return a
+}
+
 // IntMax returns the maximum of the params
+// Deprecated: please use Max
 func IntMax(a, b int) int {
 	if b > a {
 		return b
@@ -25,6 +47,7 @@ func IntMax(a, b int) int {
 }
 
 // IntMin returns the minimum of the params
+// Deprecated: please use Min
 func IntMin(a, b int) int {
 	if b < a {
 		return b
@@ -33,6 +56,7 @@ func IntMin(a, b int) int {
 }
 
 // Int32Max returns the maximum of the params
+// Deprecated: please use Max
 func Int32Max(a, b int32) int32 {
 	if b > a {
 		return b
@@ -41,6 +65,7 @@ func Int32Max(a, b int32) int32 {
 }
 
 // Int32Min returns the minimum of the params
+// Deprecated: please use Min
 func Int32Min(a, b int32) int32 {
 	if b < a {
 		return b
@@ -49,6 +74,7 @@ func Int32Min(a, b int32) int32 {
 }
 
 // Int64Max returns the maximum of the params
+// Deprecated: please use Max
 func Int64Max(a, b int64) int64 {
 	if b > a {
 		return b
@@ -57,6 +83,7 @@ func Int64Max(a, b int64) int64 {
 }
 
 // Int64Min returns the minimum of the params
+// Deprecated: please use Min
 func Int64Min(a, b int64) int64 {
 	if b < a {
 		return b

--- a/integer/integer_test.go
+++ b/integer/integer_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package integer
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestIntMax(t *testing.T) {
 	tests := []struct {
@@ -240,5 +243,29 @@ func TestRoundToInt32(t *testing.T) {
 		if got := RoundToInt32(test.num); got != test.exp {
 			t.Errorf("expected %d, got %d", test.exp, got)
 		}
+	}
+}
+
+func TestMin(t *testing.T) {
+	if min := Min(math.MinInt, 0); min != math.MinInt {
+		t.Errorf("got %v, want %v", min, 0)
+	}
+	if min := Min(math.MinInt32, int32(0)); min != math.MinInt32 {
+		t.Errorf("got %v, want %v", min, 0)
+	}
+	if min := Min(math.MinInt64, int64(0)); min != math.MinInt64 {
+		t.Errorf("got %v, want %v", min, 0)
+	}
+}
+
+func TestMax(t *testing.T) {
+	if max := Max(math.MaxInt, 42); max != math.MaxInt {
+		t.Errorf("got %v, want %v", max, 0)
+	}
+	if max := Max(math.MaxInt32, int32(42)); max != math.MaxInt32 {
+		t.Errorf("got %v, want %v", max, 0)
+	}
+	if max := Max(math.MaxInt64, int64(42)); max != math.MaxInt64 {
+		t.Errorf("got %v, want %v", max, 0)
 	}
 }

--- a/integer/integer_test.go
+++ b/integer/integer_test.go
@@ -256,6 +256,21 @@ func TestMin(t *testing.T) {
 	if min := Min(math.MinInt64, int64(0)); min != math.MinInt64 {
 		t.Errorf("got %v, want %v", min, 0)
 	}
+	if min := Min(uint(42), uint(0)); min != 0 {
+		t.Errorf("got %v, want %v", min, 0)
+	}
+	if min := Min(uint8(42), uint8(0)); min != 0 {
+		t.Errorf("got %v, want %v", min, 0)
+	}
+	if min := Min(uint16(42), uint16(0)); min != 0 {
+		t.Errorf("got %v, want %v", min, 0)
+	}
+	if min := Min(uint32(42), uint32(0)); min != 0 {
+		t.Errorf("got %v, want %v", min, 0)
+	}
+	if min := Min(uint64(42), uint64(0)); min != 0 {
+		t.Errorf("got %v, want %v", min, 0)
+	}
 }
 
 func TestMax(t *testing.T) {
@@ -266,6 +281,18 @@ func TestMax(t *testing.T) {
 		t.Errorf("got %v, want %v", max, 0)
 	}
 	if max := Max(math.MaxInt64, int64(42)); max != math.MaxInt64 {
+		t.Errorf("got %v, want %v", max, 0)
+	}
+	if max := Max(math.MaxUint8, uint8(42)); max != math.MaxUint8 {
+		t.Errorf("got %v, want %v", max, 0)
+	}
+	if max := Max(math.MaxUint16, uint16(42)); max != math.MaxUint16 {
+		t.Errorf("got %v, want %v", max, 0)
+	}
+	if max := Max(math.MaxUint32, uint32(42)); max != math.MaxUint32 {
+		t.Errorf("got %v, want %v", max, 0)
+	}
+	if max := Max(math.MaxUint64, uint64(42)); max != math.MaxUint64 {
 		t.Errorf("got %v, want %v", max, 0)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup


**What this PR does / why we need it**:

Generics were introduced in go 1.18, we're at 1.20 so we can start using them in the utils package.

**Release note**:
```
IntMax,IntMin,Int32Max,Int32Min,Int64Max,Int64Min are now deprecated, please use `Max` or `Min` instead.
```
