### PR TITLE
feat: Add LockWithContext method to keymutex

### DIFF
--- a/keymutex/hashed.go
+++ b/keymutex/hashed.go
@@ -56,7 +56,7 @@ func (km *hashedKeyMutex) LockKey(id string) {
 
 // Tries to acquire the associated lock within the timeframe,
 // returns true if lock is acquired, false otherwise.
-func (km *hashedKeyMutex) LockKeyWithContext(id string, ctx context.Context) bool {
+func (km *hashedKeyMutex) LockKeyWithContext(ctx context.Context, id string) bool {
 	select {
 	case <-km.channels[km.hash(id)%uint32(len(km.channels))]:
 		return true

--- a/keymutex/keymutex.go
+++ b/keymutex/keymutex.go
@@ -16,10 +16,19 @@ limitations under the License.
 
 package keymutex
 
+import (
+	"context"
+)
+
 // KeyMutex is a thread-safe interface for acquiring locks on arbitrary strings.
 type KeyMutex interface {
 	// Acquires a lock associated with the specified ID, creates the lock if one doesn't already exist.
 	LockKey(id string)
+
+	// Acquires a lock associated with the specified ID, creates the lock if one doesn't already exist.
+	// This method will return true if the lock was acquired successfully. It will return false
+	// if the context was cancelled before the lock could be acquired.
+	LockKeyWithContext(id string, ctx context.Context) bool
 
 	// Releases the lock associated with the specified ID.
 	// Returns an error if the specified ID doesn't exist.

--- a/keymutex/keymutex.go
+++ b/keymutex/keymutex.go
@@ -28,7 +28,7 @@ type KeyMutex interface {
 	// Acquires a lock associated with the specified ID, creates the lock if one doesn't already exist.
 	// This method will return true if the lock was acquired successfully. It will return false
 	// if the context was cancelled before the lock could be acquired.
-	LockKeyWithContext(id string, ctx context.Context) bool
+	LockKeyWithContext(ctx context.Context, id string) bool
 
 	// Releases the lock associated with the specified ID.
 	// Returns an error if the specified ID doesn't exist.

--- a/keymutex/keymutex_test.go
+++ b/keymutex/keymutex_test.go
@@ -88,7 +88,7 @@ func Test_LockWithContext_SingleLock_SingleUnlock(t *testing.T) {
 
 		// Act & Assert
 		ctx := context.Background()
-		go lockWithContextAndCallback(km, key, callbackCh, ctx)
+		go lockWithContextAndCallback(ctx, km, key, callbackCh)
 		verifyCallbackHappensWithVal(t, callbackCh, true)
 		km.UnlockKey(key)
 	}
@@ -103,9 +103,9 @@ func Test_LockWithContext_DoubleLock_DoubleUnlock(t *testing.T) {
 
 		// Act & Assert
 		ctx := context.Background()
-		go lockWithContextAndCallback(km, key, callbackCh1stLock, ctx)
+		go lockWithContextAndCallback(ctx, km, key, callbackCh1stLock)
 		verifyCallbackHappensWithVal(t, callbackCh1stLock, true)
-		go lockWithContextAndCallback(km, key, callbackCh2ndLock, ctx)
+		go lockWithContextAndCallback(ctx, km, key, callbackCh2ndLock)
 		verifyCallbackDoesntHappens(t, callbackCh2ndLock)
 		km.UnlockKey(key)
 		verifyCallbackHappensWithVal(t, callbackCh2ndLock, true)
@@ -123,9 +123,9 @@ func Test_LockWithContext_DoubleLock_LockCancellation(t *testing.T) {
 		// Act & Assert
 		ctx := context.Background()
 		ctx, cancel := context.WithCancel(ctx)
-		go lockWithContextAndCallback(km, key, callbackCh1stLock, ctx)
+		go lockWithContextAndCallback(ctx, km, key, callbackCh1stLock)
 		verifyCallbackHappensWithVal(t, callbackCh1stLock, true)
-		go lockWithContextAndCallback(km, key, callbackCh2ndLock, ctx)
+		go lockWithContextAndCallback(ctx, km, key, callbackCh2ndLock)
 		verifyCallbackDoesntHappens(t, callbackCh2ndLock)
 		cancel()
 		verifyCallbackHappensWithVal(t, callbackCh2ndLock, false)
@@ -138,8 +138,8 @@ func lockAndCallback(km KeyMutex, id string, callbackCh chan<- interface{}) {
 	callbackCh <- true
 }
 
-func lockWithContextAndCallback(km KeyMutex, id string, callbackCh chan<- interface{}, ctx context.Context) {
-	callbackCh <- km.LockKeyWithContext(id, ctx)
+func lockWithContextAndCallback(ctx context.Context, km KeyMutex, id string, callbackCh chan<- interface{}) {
+	callbackCh <- km.LockKeyWithContext(ctx, id)
 }
 
 func verifyCallbackHappens(t *testing.T, callbackCh <-chan interface{}) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
- As implemented, `KeyMutex` doesn't provide cancellation/timeout functionality. This results in poor behavior (unnecessary lock contention), and increases the complexity of the required caller implementation (caller must determine whether to immediately return lock if context is cancelled, etc). 
- This PR introduces a `LockWithContext` method to `KeyMutex`, which allows callers to more gracefully implement acquisition cancellation/timeouts.
- In order to implement this behavior, this PR migrates the underlying synchronization primitive from a `Mutex` to a `chan`.  This is required because `Mutex` doesn't have support for `select` or other conditional acquisition (timeouts) short of polling.

**Which issue(s) this PR fixes**:
This is a new feature. Please let me know if I need to create a corresponding issue.

**Special notes for your reviewer**:


**Release note**:
```

```
