### PR TITLE
chore: should use bytes.Equal(oldContent, newContent) instead (S1004)

### DIFF
--- a/io/read.go
+++ b/io/read.go
@@ -53,7 +53,7 @@ func consistentReadSync(filename string, attempts int, sync func(int)) ([]byte, 
 		if err != nil {
 			return nil, err
 		}
-		if bytes.Compare(oldContent, newContent) == 0 {
+		if bytes.Equal(oldContent, newContent) {
 			return newContent, nil
 		}
 		// Files are different, continue reading


### PR DESCRIPTION

**What type of PR is this?**
> /kind cleanup


**What this PR does / why we need it**:
should use bytes.Equal(oldContent, newContent) instead (S1004)
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:


**Release note**:
```

```
