### PR TITLE
Ensure set.Equal() compares the two set lengths

### DIFF
--- a/set/set.go
+++ b/set/set.go
@@ -155,7 +155,7 @@ func (s Set[E]) Difference(s2 Set[E]) Set[E] {
 // Equal returns true if and only if s1 is equal (as a set) to s2.
 // Two sets are equal if their membership is identical.
 func (s Set[E]) Equal(s2 Set[E]) bool {
-	return s.Len() == s.Len() && s.IsSuperset(s2)
+	return s.Len() == s2.Len() && s.IsSuperset(s2)
 }
 
 type sortableSlice[E ordered] []E

--- a/set/set_test.go
+++ b/set/set_test.go
@@ -169,10 +169,16 @@ func TestStringSetEquals(t *testing.T) {
 	if a.Equal(b) {
 		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
 	}
+	if b.Equal(a) {
+		t.Errorf("Expected to be not-equal: %v vs %v", b, a)
+	}
 
 	b = New[string]("1", "2", "")
 	if a.Equal(b) {
 		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+	if b.Equal(a) {
+		t.Errorf("Expected to be not-equal: %v vs %v", b, a)
 	}
 
 	// Check for equality after mutation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

set.Equal() currently checks the length of the owning set against itself, so a.Equal(b) returns true if a is a superset of b, with no further restriction.

This fixes the length check and adds unit tests to catch this case.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```

```
