### PR TITLE
Transfer go get to go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ for moving] an existing package to this repository.
 
 - Stable, or backward compatible, API, with complete godocs.
 
-- Go tools compliant (`go get`, `go install`, `go test`, etc.).
+- Go tools compliant (`go get`, `go test`, etc.).
 
 - Very few (ideally zero) external dependencies.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ for moving] an existing package to this repository.
 
 - Stable, or backward compatible, API, with complete godocs.
 
-- Go tools compliant (`go get`, `go test`, etc.).
+- Go tools compliant (`go get`, `go install`, `go test`, etc.).
 
 - Very few (ideally zero) external dependencies.
 

--- a/hack/verify-apidiff.sh
+++ b/hack/verify-apidiff.sh
@@ -65,7 +65,7 @@ fi
 if ! which apidiff > /dev/null; then
   echo "Installing golang.org/x/exp/cmd/apidiff..."
   pushd "${TMPDIR:-/tmp}" > /dev/null
-    go get golang.org/x/exp/cmd/apidiff
+    go install golang.org/x/exp/cmd/apidiff@latest
   popd > /dev/null
 fi
 

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -23,7 +23,7 @@ source "${KUBE_ROOT}/hack/lib/util.sh"
 
 if ! which golint > /dev/null; then
     echo "installing golint"
-    go get golang.org/x/lint/golint
+    go install golang.org/x/lint/golint@latest
 fi
 
 cd "${KUBE_ROOT}"


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup


**What this PR does / why we need it**:
- The command `go get` has been deprecated in Go for a few releases: https://go.dev/doc/go-get-install-deprecation
- The scripts we run in the CI for https://github.com/kubernetes/utils are under `hack/`. A few of them still use `go get` I think, and we’re using go1.18 in the repo which should have `go get` deprecated.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # _N/A_

**Special notes for your reviewer**:
_N/A_

**Release note**:
_N/A_
```

```
