### PR TITLE
Use math.Round for rounding in RoundToInt32

### DIFF
--- a/integer/integer.go
+++ b/integer/integer.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package integer
 
+import "math"
+
 // IntMax returns the maximum of the params
 func IntMax(a, b int) int {
 	if b > a {
@@ -65,9 +67,7 @@ func Int64Min(a, b int64) int64 {
 }
 
 // RoundToInt32 rounds floats into integer numbers.
+// Deprecated: use math.Round() and a cast directly.
 func RoundToInt32(a float64) int32 {
-	if a < 0 {
-		return int32(a - 0.5)
-	}
-	return int32(a + 0.5)
+	return int32(math.Round(a))
 }

--- a/integer/integer_test.go
+++ b/integer/integer_test.go
@@ -233,6 +233,10 @@ func TestRoundToInt32(t *testing.T) {
 			num: 0,
 			exp: 0,
 		},
+		{
+			num: 0.49999999999999994,
+			exp: 0,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This relies on math.Round in RoundToInt32 instead of re-implementing it (with side-effects).

Since RoundToInt32 ends up being a type-casting wrapper around math.Round, deprecate it in favour of the latter.

**Which issue(s) this PR fixes**:

Fixes #71

**Special notes for your reviewer**:


**Release note**:
```
integer.RoundToInt32 is deprecated; math.Round should be used instead.
```
