### PR TITLE
refactor ioutil usage

### DIFF
--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -19,7 +19,6 @@ package exec
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	osexec "os/exec"
 	"testing"
@@ -207,7 +206,7 @@ func TestStdIOPipes(t *testing.T) {
 func readAll(t *testing.T, r io.Reader, n string) string {
 	t.Helper()
 
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("unexpected error when reading from %s: %v", n, err)
 	}

--- a/exec/stdiopipe_test.go
+++ b/exec/stdiopipe_test.go
@@ -18,7 +18,7 @@ package exec_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"k8s.io/utils/exec"
 )
@@ -33,7 +33,7 @@ func ExampleNew_stderrPipe() {
 
 	stderr := make(chan []byte)
 	go func() {
-		b, err := ioutil.ReadAll(stderrPipe)
+		b, err := io.ReadAll(stderrPipe)
 		if err != nil {
 			panic(err)
 		}

--- a/inotify/inotify_linux_test.go
+++ b/inotify/inotify_linux_test.go
@@ -8,7 +8,6 @@
 package inotify
 
 import (
-	"io"
 	"os"
 	"sync/atomic"
 	"testing"

--- a/inotify/inotify_linux_test.go
+++ b/inotify/inotify_linux_test.go
@@ -22,7 +22,7 @@ func TestInotifyEvents(t *testing.T) {
 		t.Fatalf("NewWatcher failed: %s", err)
 	}
 
-	dir, err := io.TempDir("", "inotify")
+	dir, err := os.MkdirTemp("", "inotify")
 	if err != nil {
 		t.Fatalf("TempDir failed: %s", err)
 	}

--- a/inotify/inotify_linux_test.go
+++ b/inotify/inotify_linux_test.go
@@ -8,7 +8,7 @@
 package inotify
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -22,7 +22,7 @@ func TestInotifyEvents(t *testing.T) {
 		t.Fatalf("NewWatcher failed: %s", err)
 	}
 
-	dir, err := ioutil.TempDir("", "inotify")
+	dir, err := io.TempDir("", "inotify")
 	if err != nil {
 		t.Fatalf("TempDir failed: %s", err)
 	}

--- a/io/read.go
+++ b/io/read.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 )
 
 // ErrLimitReached means that the read limit is reached.
@@ -41,7 +41,7 @@ func ConsistentRead(filename string, attempts int) ([]byte, error) {
 // introduces a sync callback that can be used by the tests to mutate the file
 // from which the test data is being read
 func consistentReadSync(filename string, attempts int, sync func(int)) ([]byte, error) {
-	oldContent, err := ioutil.ReadFile(filename)
+	oldContent, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func consistentReadSync(filename string, attempts int, sync func(int)) ([]byte, 
 		if sync != nil {
 			sync(i)
 		}
-		newContent, err := ioutil.ReadFile(filename)
+		newContent, err := os.ReadFile(filename)
 		if err != nil {
 			return nil, err
 		}
@@ -87,7 +87,7 @@ func IsInconsistentReadError(err error) bool {
 // when `limit` bytes are read.
 func ReadAtMost(r io.Reader, limit int64) ([]byte, error) {
 	limitedReader := &io.LimitedReader{R: r, N: limit}
-	data, err := ioutil.ReadAll(limitedReader)
+	data, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return data, err
 	}

--- a/io/read_test.go
+++ b/io/read_test.go
@@ -18,7 +18,6 @@ package io
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +44,7 @@ func writeToPipe(namedPipe string, flaky bool, i int) {
 }
 
 func makePipe(t *testing.T) string {
-	tmp, err := ioutil.TempDir("", "pipe-test")
+	tmp, err := os.MkdirTemp("", "pipe-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mount/mount_helper_test.go
+++ b/mount/mount_helper_test.go
@@ -18,7 +18,6 @@ package mount
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -77,8 +76,7 @@ func TestDoCleanupMountPoint(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-
-			tmpDir, err := ioutil.TempDir("", "unmount-mount-point-test")
+			tmpDir, err := os.MkdirTemp("", "unmount-mount-point-test")
 			if err != nil {
 				t.Fatalf("failed to create tmpdir: %v", err)
 			}
@@ -120,7 +118,7 @@ func TestDoCleanupMountPoint(t *testing.T) {
 }
 
 func validateDirExists(dir string) error {
-	_, err := ioutil.ReadDir(dir)
+	_, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}
@@ -128,7 +126,7 @@ func validateDirExists(dir string) error {
 }
 
 func validateDirNotExists(dir string) error {
-	_, err := ioutil.ReadDir(dir)
+	_, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
 		return nil
 	}

--- a/mount/mount_helper_unix_test.go
+++ b/mount/mount_helper_unix_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package mount
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -28,12 +27,12 @@ import (
 )
 
 func writeFile(content string) (string, string, error) {
-	tempDir, err := ioutil.TempDir("", "mounter_shared_test")
+	tempDir, err := os.MkdirTemp("", "mounter_shared_test")
 	if err != nil {
 		return "", "", err
 	}
 	filename := filepath.Join(tempDir, "mountinfo")
-	err = ioutil.WriteFile(filename, []byte(content), 0600)
+	err = os.WriteFile(filename, []byte(content), 0600)
 	if err != nil {
 		os.RemoveAll(tempDir)
 		return "", "", err

--- a/mount/mount_linux_test.go
+++ b/mount/mount_linux_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package mount
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -419,7 +418,7 @@ func TestSearchMountPoints(t *testing.T) {
 			nil,
 		},
 	}
-	tmpFile, err := ioutil.TempFile("", "test-get-filetype")
+	tmpFile, err := os.CreateTemp("", "test-get-filetype")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mount/mount_windows_test.go
+++ b/mount/mount_windows_test.go
@@ -21,7 +21,6 @@ package mount
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -206,7 +205,8 @@ func TestIsLikelyNotMountPoint(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		base, err := ioutil.TempDir("", test.fileName)
+		
+		base, err := os.MkdirTemp("", test.fileName)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -291,7 +291,7 @@ func TestFormatAndMount(t *testing.T) {
 			Interface: &fakeMounter,
 			Exec:      fakeExec,
 		}
-		base, err := ioutil.TempDir("", test.device)
+		base, err := os.MkdirTemp("", test.device)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/mount/safe_format_and_mount_test.go
+++ b/mount/safe_format_and_mount_test.go
@@ -18,7 +18,6 @@ package mount
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -58,7 +57,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		t.Skipf("not supported on GOOS=%s", runtime.GOOS)
 	}
-	mntDir, err := ioutil.TempDir(os.TempDir(), "mount")
+	mntDir, err := os.MkdirTemp(os.TempDir(), "mount")
 	if err != nil {
 		t.Fatalf("failed to create tmp dir: %v", err)
 	}

--- a/nsenter/nsenter_test.go
+++ b/nsenter/nsenter_test.go
@@ -115,7 +115,7 @@ func TestEvalSymlinks(t *testing.T) {
 			mustExist: true,
 			prepare: func(tmpdir string) (src string, expectedDst string, err error) {
 				src = filepath.Join(tmpdir, "src")
-				err = os(src, []byte{}, 0644)
+				err = os.WriteFile(src, []byte{}, 0644)
 				return src, src, err
 			},
 		},
@@ -243,7 +243,7 @@ func TestEvalSymlinks(t *testing.T) {
 			},
 		}
 
-		tmpdir, err := os.TempDir("", "nsenter-hostpath-")
+		tmpdir, err := os.MkdirTemp("", "nsenter-hostpath-")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/nsenter/nsenter_test.go
+++ b/nsenter/nsenter_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package nsenter
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -116,7 +115,7 @@ func TestEvalSymlinks(t *testing.T) {
 			mustExist: true,
 			prepare: func(tmpdir string) (src string, expectedDst string, err error) {
 				src = filepath.Join(tmpdir, "src")
-				err = ioutil.WriteFile(src, []byte{}, 0644)
+				err = os(src, []byte{}, 0644)
 				return src, src, err
 			},
 		},
@@ -154,7 +153,7 @@ func TestEvalSymlinks(t *testing.T) {
 			mustExist: false,
 			prepare: func(tmpdir string) (src string, expectedDst string, err error) {
 				dst := filepath.Join(tmpdir, "dst")
-				if err = ioutil.WriteFile(dst, []byte{}, 0644); err != nil {
+				if err = os.WriteFile(dst, []byte{}, 0644); err != nil {
 					return "", "", err
 				}
 				src = filepath.Join(tmpdir, "src")
@@ -192,7 +191,7 @@ func TestEvalSymlinks(t *testing.T) {
 					return "", "", err
 				}
 				dstFile := filepath.Join(dst, "file")
-				if err = ioutil.WriteFile(dstFile, []byte{}, 0644); err != nil {
+				if err = os.WriteFile(dstFile, []byte{}, 0644); err != nil {
 					return "", "", err
 				}
 
@@ -244,7 +243,7 @@ func TestEvalSymlinks(t *testing.T) {
 			},
 		}
 
-		tmpdir, err := ioutil.TempDir("", "nsenter-hostpath-")
+		tmpdir, err := os.TempDir("", "nsenter-hostpath-")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -273,7 +272,7 @@ func TestNewNsenter(t *testing.T) {
 	// Create a symlink /tmp/xyz/rootfs -> / and use it as rootfs path
 	// It should resolve all binaries correctly, the test runs on Linux
 
-	tmpdir, err := ioutil.TempDir("", "nsenter-hostpath-")
+	tmpdir, err := os.MkdirTemp("", "nsenter-hostpath-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +293,7 @@ func TestNewNsenterError(t *testing.T) {
 	// Create empty dir /tmp/xyz/rootfs and use it as rootfs path
 	// It should resolve all binaries correctly, the test runs on Linux
 
-	tmpdir, err := ioutil.TempDir("", "nsenter-hostpath-")
+	tmpdir, err := os.MkdirTemp("", "nsenter-hostpath-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/temp/dir.go
+++ b/temp/dir.go
@@ -19,7 +19,6 @@ package temp
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -45,7 +44,7 @@ var _ Directory = &Dir{}
 // CreateTempDir returns a new Directory wrapping a temporary directory
 // on disk.
 func CreateTempDir(prefix string) (*Dir, error) {
-	name, err := ioutil.TempDir("", fmt.Sprintf("%s-", prefix))
+	name, err := os.MkdirTemp("", fmt.Sprintf("%s-", prefix))
 	if err != nil {
 		return nil, err
 	}

--- a/temp/dir_test.go
+++ b/temp/dir_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package temp
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +43,7 @@ func TestTempDir(t *testing.T) {
 	}
 
 	// Verify that the directory is empty
-	entries, err := ioutil.ReadDir(dir.Name)
+	entries, err := os.ReadDir(dir.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +68,7 @@ func TestTempDir(t *testing.T) {
 	}
 
 	// We have created only two files
-	entries, err = ioutil.ReadDir(dir.Name)
+	entries, err = os.ReadDir(dir.Name)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`ioutil` functions have been deprecated. This MR replaces usages of those functions with the recommended ones. More details are present in the linked issue

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/utils/issues/298

**Special notes for your reviewer**:

**Release note**:
