### PR TITLE
add test coverage to set.go

### DIFF
--- a/set/set_test.go
+++ b/set/set_test.go
@@ -151,13 +151,17 @@ func TestStringSetEquals(t *testing.T) {
 	if !a.Equal(b) {
 		t.Errorf("Expected to be equal: %v vs %v", a, b)
 	}
-
+	a = New[string]("1", "2", "3")
+	b = New[string]("2", "1")
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
 	// It is a set; duplicates are ignored
+	a = New[string]("1", "2")
 	b = New[string]("2", "2", "1")
 	if !a.Equal(b) {
 		t.Errorf("Expected to be equal: %v vs %v", a, b)
 	}
-
 	// Edge cases around empty sets / empty strings
 	a = New[string]()
 	b = New[string]()
@@ -368,4 +372,33 @@ func TestSetClearInSeparateFunction(t *testing.T) {
 func clearSetAndAdd[T ordered](s Set[T], a T) {
 	s.Clear()
 	s.Insert(a)
+}
+
+func TestPopAny(t *testing.T) {
+	a := New[string]("1", "2")
+	_, popped := a.PopAny()
+	if !popped {
+		t.Errorf("got len(%d): wanted 1", a.Len())
+	}
+	_, popped = a.PopAny()
+	if !popped {
+		t.Errorf("got len(%d): wanted 0", a.Len())
+	}
+	zeroVal, popped := a.PopAny()
+	if popped {
+		t.Errorf("got len(%d): wanted 0", a.Len())
+	}
+	if zeroVal != "" {
+		t.Errorf("should have gotten zero value when popping an empty set")
+	}
+}
+
+func TestClone(t *testing.T) {
+	a := New[string]("1", "2")
+	a.Insert("3")
+
+	got := a.Clone()
+	if !reflect.DeepEqual(got, a) {
+		t.Errorf("Expected to be equal: %v vs %v", got, a)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

Missing coverage for a few of the set methods. This PR introduces additional coverage.

**Release note**:
```
NONE
```
