### PR TITLE
.: bump go version to go1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.21.x, 1.22.x]
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -24,7 +24,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.21.x, 1.22.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/exec/fixup_go118.go
+++ b/exec/fixup_go118.go
@@ -1,5 +1,4 @@
 //go:build !go1.19
-// +build !go1.19
 
 /*
 Copyright 2022 The Kubernetes Authors.

--- a/exec/fixup_go119.go
+++ b/exec/fixup_go119.go
@@ -1,5 +1,4 @@
 //go:build go1.19
-// +build go1.19
 
 /*
 Copyright 2022 The Kubernetes Authors.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/utils
 
-go 1.18
+go 1.21
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/inotify/inotify_linux.go
+++ b/inotify/inotify_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2010 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/inotify/inotify_linux_test.go
+++ b/inotify/inotify_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2010 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/inotify/inotify_others.go
+++ b/inotify/inotify_others.go
@@ -1,4 +1,4 @@
-// +build !linux
+//go:build !linux
 
 /*
 Copyright 2020 The Kubernetes Authors.

--- a/mount/mount_helper_unix.go
+++ b/mount/mount_helper_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright 2019 The Kubernetes Authors.

--- a/mount/mount_helper_unix_test.go
+++ b/mount/mount_helper_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright 2019 The Kubernetes Authors.

--- a/mount/mount_helper_windows.go
+++ b/mount/mount_helper_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2019 The Kubernetes Authors.

--- a/mount/mount_helper_windows_test.go
+++ b/mount/mount_helper_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2014 The Kubernetes Authors.

--- a/mount/mount_linux_test.go
+++ b/mount/mount_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2014 The Kubernetes Authors.

--- a/mount/mount_unsupported.go
+++ b/mount/mount_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 /*
 Copyright 2014 The Kubernetes Authors.

--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/mount/mount_windows_test.go
+++ b/mount/mount_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/nsenter/nsenter.go
+++ b/nsenter/nsenter.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/nsenter/nsenter_test.go
+++ b/nsenter/nsenter_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2018 The Kubernetes Authors.

--- a/nsenter/nsenter_unsupported.go
+++ b/nsenter/nsenter_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
 Copyright 2017 The Kubernetes Authors.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

go1.20 is out of support as of ~3 weeks ago and all supported k/k release branches are on go1.21.
This PR bumps version of Go to 1.21.

This PR also cleans up the build tag directives and consistently uses only `//go:build` now

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
@dims @liggitt - I'm wondering if we put in `go1.21.x` in the `go.mod` or an overall release version like `go1.21` should do like we do in k/k?

**Release note**:
```
NONE
```

/assign @dims @liggitt 
