### PR TITLE
.*: add presubmit check for verifying go directive changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,22 @@ jobs:
     - name: Test
       run: |
         make test
+  verify-go-directive:
+    strategy:
+      matrix:
+        go-version: [1.20.x, 1.21.x]
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Verify go directive
+      run: |
+        make verify-go-directive
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,10 @@ vet:
 .PHONY: update-fmt
 update-fmt:
 	gofmt -s -w .
+
+# We set the maximum version of the go directive as 1.20 here
+# because the oldest go directive that exists on our supported
+# release branches in k/k is 1.20.
+.PHONY: verify-go-directive
+verify-go-directive:
+	./hack/verify-go-directive.sh -g 1.20

--- a/hack/verify-go-directive.sh
+++ b/hack/verify-go-directive.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function usage {
+  local script="$(basename $0)"
+
+  echo >&2 "Usage: ${script} [-g <maximum go directive>]
+
+This script should be run at the root of a module.
+
+-g <maximum go directive>
+  Compare the go directive in the local working copy's go.mod
+  to the specified maximum version it can be. Versions provided
+  here are of the form 1.x.y, without the 'go' prefix.
+
+Examples:
+  ${script} -g 1.20
+  ${script} -g 1.21.6
+"
+  exit 1
+}
+
+max=""
+while getopts g: o
+do case "$o" in
+  g)    max="$OPTARG";;
+  [?])  usage;;
+  esac
+done
+
+# If max is empty, print usage and error
+if [[ -z "${max}" ]]; then
+  usage;
+fi
+
+# Don't specify the version with the go prefix, just 1.x.y will do.
+if ! printf '%s\n' "${max}" | grep -v -q "^go"; then
+  usage;
+fi
+
+current=$(grep '^go [1-9]*' go.mod | cut -d ' ' -f2)
+if [[ -z "${current}" ]]; then
+  echo >&2 "FAIL: could not get value of go directive from go.mod"
+  exit 1
+fi
+
+if ! printf '%s\n' "${current}" "${max}" | sort --check=silent --version-sort; then
+    echo >&2 "FAIL: current Go directive ${current} is greater than ${max}"
+    exit 1
+fi


### PR DESCRIPTION
This commit adds a script that checks the changed version in the go.mod file with a certain maximum version that the go directive can have.

We set the maximum version of the go directive as 1.20 here because the oldest go directive that exists on our supported release branches in k/k is 1.20.

This commit additionally changes the requisite GH action to incorporate this check.

Fixes https://github.com/kubernetes/utils/issues/305
xref https://github.com/kubernetes/kubernetes/issues/123744

/sig architecture 
/area code-organization
/kind cleanup
/assign @dims @liggitt 