### PR TITLE
add netip utils

### DIFF
--- a/net/netip.go
+++ b/net/netip.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+)
+
+// IPToAddr converts a net.IP to a netip.Addr
+// if the net.IP is not valid it returns an empty netip.Addr{}
+func IPToAddr(ip net.IP) netip.Addr {
+	// https://pkg.go.dev/net/netip#AddrFromSlice can return an IPv4 in IPv6 format
+	// so we have to check the IP family to return exactly the format that we want
+	// address, _ := netip.AddrFromSlice(net.ParseIPSloppy(192.168.0.1)) returns
+	// an address like ::ffff:192.168.0.1/32
+	bytes := ip.To4()
+	if bytes == nil {
+		bytes = ip.To16()
+	}
+	// AddrFromSlice returns Addr{}, false if the input is invalid.
+	address, _ := netip.AddrFromSlice(bytes)
+	return address
+}
+
+// BroadcastAddress returns the broadcast address of the subnet
+// The broadcast address is obtained by setting all the host bits
+// in a subnet to 1.
+// network 192.168.0.0/24 : subnet bits 24 host bits 32 - 24 = 8
+// broadcast address 192.168.0.255
+func BroadcastAddress(subnet netip.Prefix) (netip.Addr, error) {
+	base := subnet.Masked().Addr()
+	bytes := base.AsSlice()
+	// get all the host bits from the subnet
+	n := 8*len(bytes) - subnet.Bits()
+	// set all the host bits to 1
+	for i := len(bytes) - 1; i >= 0 && n > 0; i-- {
+		if n >= 8 {
+			bytes[i] = 0xff
+			n -= 8
+		} else {
+			mask := ^uint8(0) >> (8 - n)
+			bytes[i] |= mask
+			break
+		}
+	}
+
+	addr, ok := netip.AddrFromSlice(bytes)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("invalid address %v", bytes)
+	}
+	return addr, nil
+}

--- a/net/netip_test.go
+++ b/net/netip_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"net"
+	"net/netip"
+	"reflect"
+	"testing"
+)
+
+func TestBroadcastAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		subnet  netip.Prefix
+		want    netip.Addr
+		wantErr bool
+	}{
+		{
+			name:    "emty subnet",
+			wantErr: true,
+		},
+		{
+			name:   "IPv4 even mask",
+			subnet: netip.MustParsePrefix("192.168.0.0/24"),
+			want:   netip.MustParseAddr("192.168.0.255"),
+		},
+		{
+			name:   "IPv4 odd mask",
+			subnet: netip.MustParsePrefix("192.168.0.0/23"),
+			want:   netip.MustParseAddr("192.168.1.255"),
+		},
+		{
+			name:   "IPv6 even mask",
+			subnet: netip.MustParsePrefix("fd00:1:2:3::/64"),
+			want:   netip.MustParseAddr("fd00:1:2:3:ffff:ffff:ffff:ffff"),
+		},
+		{
+			name:   "IPv6 odd mask",
+			subnet: netip.MustParsePrefix("fd00:1:2:3::/57"),
+			want:   netip.MustParseAddr("fd00:1:2:007f:ffff:ffff:ffff:ffff"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BroadcastAddress(tt.subnet)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BroadcastAddress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BroadcastAddress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIPToAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want netip.Addr
+	}{
+		{
+			name: "IPv4",
+			ip:   "192.168.2.2",
+			want: netip.MustParseAddr("192.168.2.2"),
+		},
+		{
+			name: "IPv6",
+			ip:   "2001:db8::2",
+			want: netip.MustParseAddr("2001:db8::2"),
+		},
+		{
+			name: "IPv4 in IPv6",
+			ip:   "::ffff:192.168.0.1",
+			want: netip.MustParseAddr("192.168.0.1"),
+		},
+		{
+			name: "invalid",
+			ip:   "invalid_ip",
+			want: netip.Addr{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if got := IPToAddr(ip); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IPToAddr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
 /kind feature

**What this PR does / why we need it**:

During the new feature added to the apiserver to handle multiple ServiceCIDR that new netip golang library was used , see https://github.com/kubernetes/kubernetes/pull/122888/files

There are two helper functions that are used in several places and that can be better be part of the utils library:

- IPToAddr: converts a net.IP to a netip.Addr
- BroadcastAddress: returns the broadcast address of a given netip.Prefix, useful to check if given an IP this is a HostIP, i.e. it is contained in the prefix and is not the subnet address or the broadcast address (for IPv4)