### PR TITLE
Add WithDeadlineTimer interface to clock

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -117,10 +117,10 @@ func (RealClock) NewTimer(d time.Duration) Timer {
 	}
 }
 
-// NewDeadlineTimer is the same as time.NewTimer(ts.Sub(time.Now()))
+// NewDeadlineTimer is the same as time.NewTimer(time.Until(ts))
 func (RealClock) NewDeadlineTimer(ts time.Time) Timer {
 	return &realTimer{
-		timer: time.NewTimer(ts.Sub(time.Now())),
+		timer: time.NewTimer(time.Until(ts)),
 	}
 }
 

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -81,6 +81,15 @@ type Ticker interface {
 
 var _ = WithTicker(RealClock{})
 
+// WithDeadlineTimer extends Clock to add NewDeadlineTimer which fires at a given moment of time.
+type WithDeadlineTimer interface {
+	Clock
+	// NewDeadlineTimer returns a new Timer which fires at ts.
+	NewDeadlineTimer(ts time.Time) Timer
+}
+
+var _ = WithDeadlineTimer(RealClock{})
+
 // RealClock really calls time.Now()
 type RealClock struct{}
 
@@ -105,6 +114,13 @@ func (RealClock) After(d time.Duration) <-chan time.Time {
 func (RealClock) NewTimer(d time.Duration) Timer {
 	return &realTimer{
 		timer: time.NewTimer(d),
+	}
+}
+
+// NewDeadlineTimer is the same as time.NewTimer(ts.Sub(time.Now()))
+func (RealClock) NewDeadlineTimer(ts time.Time) Timer {
+	return &realTimer{
+		timer: time.NewTimer(ts.Sub(time.Now())),
 	}
 }
 

--- a/clock/testing/fake_clock_test.go
+++ b/clock/testing/fake_clock_test.go
@@ -332,6 +332,32 @@ func TestTimerNegative(t *testing.T) {
 	}
 }
 
+func TestDeadlineTimerFakeStop(t *testing.T) {
+	tc := NewFakeClock(time.Now())
+	timer := tc.NewDeadlineTimer(tc.Now().Add(time.Second))
+	if !tc.HasWaiters() {
+		t.Errorf("expected a waiter to be present, but it is not")
+	}
+	timer.Stop()
+	if tc.HasWaiters() {
+		t.Errorf("expected existing waiter to be cleaned up, but it is still present")
+	}
+}
+
+func TestDeadlineTimerNegative(t *testing.T) {
+	tc := NewFakeClock(time.Now())
+	timer := tc.NewDeadlineTimer(tc.Now().Add(-1 * time.Second))
+	if !tc.HasWaiters() {
+		t.Errorf("expected a waiter to be present, but it is not")
+	}
+	// force waiters to be called
+	tc.Step(0)
+	tick := assertReadTime(t, timer.C())
+	if tick != tc.Now() {
+		t.Errorf("expected -1s to turn into now: %v != %v", tick, tc.Now())
+	}
+}
+
 func TestTickNegative(t *testing.T) {
 	// The stdlib 'Tick' returns nil for negative and zero values, so our fake
 	// should too.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This is a part of effort to fix https://github.com/kubernetes/kubernetes/issues/125581

WithDeadlineTimer interface extends Clock to add NewDeadlineTimer. NewDeadlineTimer is similar to NewTimer, but it returns a timer which fires at the given timestamp.  It makes unit testing easier with FakeClock.Step when a test subject is making a timer inside goroutine (e.g., workqueue.NewDelayingQueue).  With NewTimer, in some race conditions, a timer never fire if FakeClock.Step is called after getting the base time Now() and calling NewTimer().  This is because the duration passed to timer is calculated against the old timestamp, but inside FakeClock.NewTimer, the targetTime is calculated against the time adjusted by Step.  With NewDeadlineTimer, targetTime is not adjusted, which works around this issue.

Because workqueue.DelayingQueueConfig uses clock.WithTicker and changing it breaks API compatibility, I plan to do type assertion like so to use NewDeadlineTimer if available:

```patch
diff --git a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
index 958b96a80c3..e3bebd36987 100644
--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -251,6 +251,14 @@ func (q *delayingType[T]) AddAfter(item T, duration time.Duration) {
        }
 }
 
+type deadlineTimerClock struct {
+       clock.Clock
+}
+
+func (c deadlineTimerClock) NewDeadlineTimer(ts time.Time) clock.Timer {
+       return c.NewTimer(ts.Sub(c.Now()))
+}
+
 // maxWait keeps a max bound on the wait time. It's just insurance against weird things happening.
 // Checking the queue every 10 seconds isn't expensive and we know that we'll never end up with an
 // expired item sitting for more than 10 seconds.
@@ -271,6 +279,11 @@ func (q *delayingType[T]) waitingLoop() {
 
        waitingEntryByData := map[t]*waitFor{}
 
+       deadlineClock, ok := q.clock.(clock.WithDeadlineTimer)
+       if !ok {
+               deadlineClock = deadlineTimerClock{Clock: q.clock}
+       }
+
        for {
                if q.TypedInterface.ShuttingDown() {
                        return
@@ -297,7 +310,7 @@ func (q *delayingType[T]) waitingLoop() {
                                nextReadyAtTimer.Stop()
                        }
                        entry := waitingForQueue.Peek().(*waitFor)
-                       nextReadyAtTimer = q.clock.NewTimer(entry.readyAt.Sub(now))
+                       nextReadyAtTimer = deadlineClock.NewDeadlineTimer(entry.readyAt)
                        nextReadyAt = nextReadyAtTimer.C()
                } 
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

https://github.com/kubernetes/kubernetes/issues/125581

**Special notes for your reviewer**:


**Release note**:
```
This PR adds WithDeadlineTimer interface extends Clock to add NewDeadlineTimer. NewDeadlineTimer is similar to NewTimer, but it returns a timer which fires at the given timestamp.
```
