### PR TITLE
Support checking if obj is a nil ptr

### DIFF
--- a/ptr/ptr.go
+++ b/ptr/ptr.go
@@ -71,3 +71,10 @@ func Equal[T comparable](a, b *T) bool {
 	}
 	return *a == *b
 }
+
+// IsNilPtr checks if the provided object is a nil pointer. This is specially useful when dealing
+// with interfaces that may hold pointers.
+func IsNilPtr(obj any) bool {
+	v := reflect.ValueOf(obj)
+	return v.Kind() == reflect.Ptr && v.IsNil()
+}

--- a/ptr/ptr_test.go
+++ b/ptr/ptr_test.go
@@ -122,3 +122,23 @@ func TestEqual(t *testing.T) {
 		t.Errorf("expected false (val != val)")
 	}
 }
+
+func TestIsNilPtr(t *testing.T) {
+	var nilIntPointer *int
+	testCases := []struct {
+		obj      interface{}
+		expected bool
+	}{
+		{(*struct{})(nil), true},
+		{&struct{}{}, false},
+		{nilIntPointer, true},
+	}
+	for i, tc := range testCases {
+		name := fmt.Sprintf("case[%d]", i)
+		t.Run(name, func(t *testing.T) {
+			if actual := ptr.IsNilPtr(tc.obj); actual != tc.expected {
+				t.Errorf("%s: expected %t, got %t", name, tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
IsNilPtr checks if the provided object is a nil pointer. This is specially useful when dealing with interfaces that may hold pointers.

Relevant issues:  https://github.com/kubernetes/kubernetes/issues/125561,https://github.com/kubernetes/kubernetes/pull/125563

> the nil checking for interface RuntimeHandlerResolver in #L109 will never check whether the underlying struct is nil.
A reflect nil checking is needed to avoid panic in running 'rcManager.LookupRuntimeHandler'(#L111)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```

```
