### PR TITLE
Deprecate strings/slices functions covered by stdlib slices

### DIFF
--- a/strings/slices/slices.go
+++ b/strings/slices/slices.go
@@ -20,21 +20,14 @@ limitations under the License.
 // replace "stringslices" if the "slices" package becomes standard.
 package slices
 
+import goslices "slices"
+
 // Equal reports whether two slices are equal: the same length and all
 // elements equal. If the lengths are different, Equal returns false.
 // Otherwise, the elements are compared in index order, and the
 // comparison stops at the first unequal pair.
-func Equal(s1, s2 []string) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	for i, n := range s1 {
-		if n != s2[i] {
-			return false
-		}
-	}
-	return true
-}
+// Deprecated: use [slices.Equal] instead.
+var Equal = goslices.Equal[[]string, string]
 
 // Filter appends to d each element e of s for which keep(e) returns true.
 // It returns the modified d. d may be s[:0], in which case the kept
@@ -51,32 +44,14 @@ func Filter(d, s []string, keep func(string) bool) []string {
 }
 
 // Contains reports whether v is present in s.
-func Contains(s []string, v string) bool {
-	return Index(s, v) >= 0
-}
+// Deprecated: use [slices.Contains] instead.
+var Contains = goslices.Contains[[]string, string]
 
 // Index returns the index of the first occurrence of v in s, or -1 if
 // not present.
-func Index(s []string, v string) int {
-	// "Contains" may be replaced with "Index(s, v) >= 0":
-	// https://github.com/golang/go/issues/45955#issuecomment-873377947
-	for i, n := range s {
-		if n == v {
-			return i
-		}
-	}
-	return -1
-}
-
-// Functions below are not in https://github.com/golang/go/issues/45955
+// Deprecated: use [slices.Index] instead.
+var Index = goslices.Index[[]string, string]
 
 // Clone returns a new clone of s.
-func Clone(s []string) []string {
-	// https://github.com/go101/go101/wiki/There-is-not-a-perfect-way-to-clone-slices-in-Go
-	if s == nil {
-		return nil
-	}
-	c := make([]string, len(s))
-	copy(c, s)
-	return c
-}
+// Deprecated: use [slices.Clone] instead.
+var Clone = goslices.Clone[[]string, string]


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

As suggested by @thockin in [1], deprecate the functions in the k8s.io/utils/strings/slices package that are already covered by generic functions in the Go standard library slices package. Also reimplement them in terms of slices functions.

[1] https://github.com/kubernetes/kubernetes/pull/126715#pullrequestreview-2241525172

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
Deprecate k8s.io/utils/strings/slices functions covered by the Go standard libary slices package.
```
