### PR TITLE
Add a helper method to set eviction function after construction

### DIFF
--- a/lru/lru.go
+++ b/lru/lru.go
@@ -16,6 +16,7 @@ limitations under the License.
 package lru
 
 import (
+	"fmt"
 	"sync"
 
 	groupcache "k8s.io/utils/internal/third_party/forked/golang/golang-lru"
@@ -42,6 +43,15 @@ func NewWithEvictionFunc(size int, f EvictionFunc) *Cache {
 	c := New(size)
 	c.cache.OnEvicted = f
 	return c
+}
+
+// SetEvictionFunc updates the eviction func
+func (c *Cache) SetEvictionFunc(f EvictionFunc) error {
+	if c.cache.OnEvicted != nil {
+		return fmt.Errorf("lru cache eviction function is already set")
+	}
+	c.cache.OnEvicted = f
+	return nil
 }
 
 // Add adds a value to the cache.

--- a/lru/lru_test.go
+++ b/lru/lru_test.go
@@ -130,3 +130,31 @@ func TestEviction(t *testing.T) {
 		t.Errorf("unexpected eviction data: key=%v val=%v", seenKey, seenVal)
 	}
 }
+
+func TestSetEviction(t *testing.T) {
+	var seenKey Key
+	var seenVal interface{}
+
+	lru := New(1)
+
+	err := lru.SetEvictionFunc(func(key Key, value interface{}) {
+		seenKey = key
+		seenVal = value
+	})
+
+	if err != nil {
+		t.Errorf("unexpected error setting eviction function: %v", err)
+	}
+
+	lru.Add(1, 2)
+	lru.Add(3, 4)
+
+	if seenKey != 1 || seenVal != 2 {
+		t.Errorf("unexpected eviction data: key=%v val=%v", seenKey, seenVal)
+	}
+
+	err = lru.SetEvictionFunc(func(key Key, value interface{}) {})
+	if err == nil {
+		t.Errorf("expected error but got none")
+	}
+}


### PR DESCRIPTION
We have a use case in https://github.com/kubernetes/kubernetes/pull/128507 where we set `OnEvicted` later.

https://github.com/dims/utils/pull/new/add-a-helper-method-to-set-eviction-function-after-construction

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
Add a new `SetEvictionFunc` in lru's Cache
```
