### PR TITLE
[Fake clock] Make Stop / Reset return false if Timer stopped

### DIFF
--- a/clock/testing/fake_clock.go
+++ b/clock/testing/fake_clock.go
@@ -48,7 +48,6 @@ type fakeClockWaiter struct {
 	stepInterval  time.Duration
 	skipIfBlocked bool
 	destChan      chan time.Time
-	fired         bool
 	afterFunc     func()
 }
 
@@ -198,12 +197,10 @@ func (f *FakeClock) setTimeLocked(t time.Time) {
 			if w.skipIfBlocked {
 				select {
 				case w.destChan <- t:
-					w.fired = true
 				default:
 				}
 			} else {
 				w.destChan <- t
-				w.fired = true
 			}
 
 			if w.afterFunc != nil {
@@ -336,7 +333,6 @@ func (f *fakeTimer) Reset(d time.Duration) bool {
 
 	active := false
 
-	f.waiter.fired = false
 	f.waiter.targetTime = f.fakeClock.time.Add(d)
 
 	for i := range f.fakeClock.waiters {


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

This is a bug in the fake clock implementation, but not one that impacts K8s users.

**What this PR does / why we need it**:

In order to conform to the standard library Timer, Stop and Reset should return false if the Timer has already been stopped, which was not the case previously.

We add unit tests to validate the new implementation. The updated TestFakeStop test case and the new TestFakeReset/reset_stopped_timer case fail with the old implementation.

We also simplify the implementation of Stop and Rest in the following way: there is no need to check f.waiter.fired to determine whether a Timer has expired. For Timers, this flag is set atomically with the waiter being removed from the waiters list. As a result, we only check for absence of the waiter from the list, which either indicates that the Timer has been stopped or that it has already expired (fired).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:


**Release note**:
```

```
