### PR TITLE
Replace all interface{} with any (Go 1.18+)

### DIFF
--- a/buffer/ring_growing.go
+++ b/buffer/ring_growing.go
@@ -19,7 +19,7 @@ package buffer
 // RingGrowing is a growing ring buffer.
 // Not thread safe.
 type RingGrowing struct {
-	data     []interface{}
+	data     []any
 	n        int // Size of Data
 	beg      int // First available element
 	readable int // Number of data items available
@@ -28,13 +28,13 @@ type RingGrowing struct {
 // NewRingGrowing constructs a new RingGrowing instance with provided parameters.
 func NewRingGrowing(initialSize int) *RingGrowing {
 	return &RingGrowing{
-		data: make([]interface{}, initialSize),
+		data: make([]any, initialSize),
 		n:    initialSize,
 	}
 }
 
 // ReadOne reads (consumes) first item from the buffer if it is available, otherwise returns false.
-func (r *RingGrowing) ReadOne() (data interface{}, ok bool) {
+func (r *RingGrowing) ReadOne() (data any, ok bool) {
 	if r.readable == 0 {
 		return nil, false
 	}
@@ -51,11 +51,11 @@ func (r *RingGrowing) ReadOne() (data interface{}, ok bool) {
 }
 
 // WriteOne adds an item to the end of the buffer, growing it if it is full.
-func (r *RingGrowing) WriteOne(data interface{}) {
+func (r *RingGrowing) WriteOne(data any) {
 	if r.readable == r.n {
 		// Time to grow
 		newN := r.n * 2
-		newData := make([]interface{}, newN)
+		newData := make([]any, newN)
 		to := r.beg + r.readable
 		if to <= r.n {
 			copy(newData, r.data[r.beg:to])

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -53,7 +53,7 @@ func StringDiff(a, b string) string {
 // ObjectDiff writes the two objects out as JSON and prints out the identical part of
 // the objects followed by the remaining part of 'a' and finally the remaining part of 'b'.
 // For debugging tests.
-func ObjectDiff(a, b interface{}) string {
+func ObjectDiff(a, b any) string {
 	ab, err := json.Marshal(a)
 	if err != nil {
 		panic(fmt.Sprintf("a: %v", err))
@@ -70,7 +70,7 @@ func ObjectDiff(a, b interface{}) string {
 // (go's %#v formatters OTOH stop at a certain point). This is needed when you
 // can't figure out why reflect.DeepEqual is returning false and nothing is
 // showing you differences. This will.
-func ObjectGoPrintDiff(a, b interface{}) string {
+func ObjectGoPrintDiff(a, b any) string {
 	s := spew.ConfigState{DisableMethods: true}
 	return StringDiff(
 		s.Sprintf("%#v", a),
@@ -79,7 +79,7 @@ func ObjectGoPrintDiff(a, b interface{}) string {
 }
 
 // ObjectReflectDiff returns a diff computed through reflection, without serializing to JSON.
-func ObjectReflectDiff(a, b interface{}) string {
+func ObjectReflectDiff(a, b any) string {
 	vA, vB := reflect.ValueOf(a), reflect.ValueOf(b)
 	if vA.Type() != vB.Type() {
 		return fmt.Sprintf("type A %T and type B %T do not match", a, b)
@@ -104,7 +104,7 @@ func ObjectReflectDiff(a, b interface{}) string {
 // 1. stringifies aObj and bObj
 // 2. elides identical prefixes if either is too long
 // 3. elides remaining content from the end if either is too long
-func limit(aObj, bObj interface{}, max int) (string, string) {
+func limit(aObj, bObj any, max int) (string, string) {
 	elidedPrefix := ""
 	elidedASuffix := ""
 	elidedBSuffix := ""
@@ -155,7 +155,7 @@ func public(s string) bool {
 
 type diff struct {
 	path *field.Path
-	a, b interface{}
+	a, b any
 }
 
 type orderedDiffs []diff
@@ -232,7 +232,7 @@ func objectReflectDiff(path *field.Path, a, b reflect.Value) []diff {
 		if reflect.DeepEqual(a.Interface(), b.Interface()) {
 			return nil
 		}
-		aKeys := make(map[interface{}]interface{})
+		aKeys := make(map[any]any)
 		for _, key := range a.MapKeys() {
 			aKeys[key.Interface()] = a.MapIndex(key).Interface()
 		}
@@ -269,7 +269,7 @@ func objectReflectDiff(path *field.Path, a, b reflect.Value) []diff {
 
 // ObjectGoPrintSideBySide prints a and b as textual dumps side by side,
 // enabling easy visual scanning for mismatches.
-func ObjectGoPrintSideBySide(a, b interface{}) string {
+func ObjectGoPrintSideBySide(a, b any) string {
 	s := spew.ConfigState{
 		Indent: " ",
 		// Extra deep spew.

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -24,7 +24,7 @@ func TestObjectReflectDiff(t *testing.T) {
 	type struct1 struct{ A []int }
 
 	testCases := map[string]struct {
-		a, b interface{}
+		a, b any
 		out  string
 	}{
 		"map": {
@@ -75,7 +75,7 @@ object.A:
   a: []int(nil)
   b: []int{}`,
 		},
-		"display type differences": {a: []interface{}{int64(1)}, b: []interface{}{uint64(1)}, out: `
+		"display type differences": {a: []any{int64(1)}, b: []any{uint64(1)}, out: `
 object[0]:
   a: 1 (int64)
   b: 0x1 (uint64)`,
@@ -102,8 +102,8 @@ func TestStringDiff(t *testing.T) {
 
 func TestLimit(t *testing.T) {
 	testcases := []struct {
-		a       interface{}
-		b       interface{}
+		a       any
+		b       any
 		expectA string
 		expectB string
 	}{

--- a/internal/third_party/forked/golang/golang-lru/lru.go
+++ b/internal/third_party/forked/golang/golang-lru/lru.go
@@ -27,18 +27,18 @@ type Cache struct {
 
 	// OnEvicted optionally specifies a callback function to be
 	// executed when an entry is purged from the cache.
-	OnEvicted func(key Key, value interface{})
+	OnEvicted func(key Key, value any)
 
 	ll    *list.List
-	cache map[interface{}]*list.Element
+	cache map[any]*list.Element
 }
 
 // A Key may be any value that is comparable. See http://golang.org/ref/spec#Comparison_operators
-type Key interface{}
+type Key any
 
 type entry struct {
 	key   Key
-	value interface{}
+	value any
 }
 
 // New creates a new Cache.
@@ -48,14 +48,14 @@ func New(maxEntries int) *Cache {
 	return &Cache{
 		MaxEntries: maxEntries,
 		ll:         list.New(),
-		cache:      make(map[interface{}]*list.Element),
+		cache:      make(map[any]*list.Element),
 	}
 }
 
 // Add adds a value to the cache.
-func (c *Cache) Add(key Key, value interface{}) {
+func (c *Cache) Add(key Key, value any) {
 	if c.cache == nil {
-		c.cache = make(map[interface{}]*list.Element)
+		c.cache = make(map[any]*list.Element)
 		c.ll = list.New()
 	}
 	if ee, ok := c.cache[key]; ok {
@@ -71,7 +71,7 @@ func (c *Cache) Add(key Key, value interface{}) {
 }
 
 // Get looks up a key's value from the cache.
-func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+func (c *Cache) Get(key Key) (value any, ok bool) {
 	if c.cache == nil {
 		return
 	}

--- a/keymutex/keymutex_test.go
+++ b/keymutex/keymutex_test.go
@@ -38,7 +38,7 @@ func Test_SingleLock_NoUnlock(t *testing.T) {
 	for _, km := range newKeyMutexes() {
 		// Arrange
 		key := "fakeid"
-		callbackCh := make(chan interface{})
+		callbackCh := make(chan any)
 
 		// Act
 		go lockAndCallback(km, key, callbackCh)
@@ -52,7 +52,7 @@ func Test_SingleLock_SingleUnlock(t *testing.T) {
 	for _, km := range newKeyMutexes() {
 		// Arrange
 		key := "fakeid"
-		callbackCh := make(chan interface{})
+		callbackCh := make(chan any)
 
 		// Act & Assert
 		go lockAndCallback(km, key, callbackCh)
@@ -65,8 +65,8 @@ func Test_DoubleLock_DoubleUnlock(t *testing.T) {
 	for _, km := range newKeyMutexes() {
 		// Arrange
 		key := "fakeid"
-		callbackCh1stLock := make(chan interface{})
-		callbackCh2ndLock := make(chan interface{})
+		callbackCh1stLock := make(chan any)
+		callbackCh2ndLock := make(chan any)
 
 		// Act & Assert
 		go lockAndCallback(km, key, callbackCh1stLock)
@@ -79,12 +79,12 @@ func Test_DoubleLock_DoubleUnlock(t *testing.T) {
 	}
 }
 
-func lockAndCallback(km KeyMutex, id string, callbackCh chan<- interface{}) {
+func lockAndCallback(km KeyMutex, id string, callbackCh chan<- any) {
 	km.LockKey(id)
 	callbackCh <- true
 }
 
-func verifyCallbackHappens(t *testing.T, callbackCh <-chan interface{}) bool {
+func verifyCallbackHappens(t *testing.T, callbackCh <-chan any) bool {
 	select {
 	case <-callbackCh:
 		return true
@@ -94,7 +94,7 @@ func verifyCallbackHappens(t *testing.T, callbackCh <-chan interface{}) bool {
 	}
 }
 
-func verifyCallbackDoesntHappens(t *testing.T, callbackCh <-chan interface{}) bool {
+func verifyCallbackDoesntHappens(t *testing.T, callbackCh <-chan any) bool {
 	select {
 	case <-callbackCh:
 		t.Fatalf("Unexpected callback.")

--- a/lru/lru.go
+++ b/lru/lru.go
@@ -23,7 +23,7 @@ import (
 )
 
 type Key = groupcache.Key
-type EvictionFunc = func(key Key, value interface{})
+type EvictionFunc = func(key Key, value any)
 
 // Cache is a thread-safe fixed size LRU cache.
 type Cache struct {
@@ -57,14 +57,14 @@ func (c *Cache) SetEvictionFunc(f EvictionFunc) error {
 }
 
 // Add adds a value to the cache.
-func (c *Cache) Add(key Key, value interface{}) {
+func (c *Cache) Add(key Key, value any) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.cache.Add(key, value)
 }
 
 // Get looks up a key's value from the cache.
-func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+func (c *Cache) Get(key Key) (value any, ok bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	return c.cache.Get(key)

--- a/lru/lru_test.go
+++ b/lru/lru_test.go
@@ -48,8 +48,8 @@ type complexStruct struct {
 
 var getTests = []struct {
 	name       string
-	keyToAdd   interface{}
-	keyToGet   interface{}
+	keyToAdd   any
+	keyToGet   any
 	expectedOk bool
 }{
 	{"string_hit", "myKey", "myKey", true},
@@ -116,9 +116,9 @@ func TestGetRace(t *testing.T) {
 
 func TestEviction(t *testing.T) {
 	var seenKey Key
-	var seenVal interface{}
+	var seenVal any
 
-	lru := NewWithEvictionFunc(1, func(key Key, value interface{}) {
+	lru := NewWithEvictionFunc(1, func(key Key, value any) {
 		seenKey = key
 		seenVal = value
 	})
@@ -133,11 +133,11 @@ func TestEviction(t *testing.T) {
 
 func TestSetEviction(t *testing.T) {
 	var seenKey Key
-	var seenVal interface{}
+	var seenVal any
 
 	lru := New(1)
 
-	err := lru.SetEvictionFunc(func(key Key, value interface{}) {
+	err := lru.SetEvictionFunc(func(key Key, value any) {
 		seenKey = key
 		seenVal = value
 	})
@@ -153,7 +153,7 @@ func TestSetEviction(t *testing.T) {
 		t.Errorf("unexpected eviction data: key=%v val=%v", seenKey, seenVal)
 	}
 
-	err = lru.SetEvictionFunc(func(key Key, value interface{}) {})
+	err = lru.SetEvictionFunc(func(key Key, value any) {})
 	if err == nil {
 		t.Errorf("expected error but got none")
 	}

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -110,7 +110,7 @@ func (mountError MountError) Error() string {
 	return mountError.Message
 }
 
-func NewMountError(mountErrorValue MountErrorType, format string, args ...interface{}) error {
+func NewMountError(mountErrorValue MountErrorType, format string, args ...any) error {
 	mountError := MountError{
 		Type:    mountErrorValue,
 		Message: fmt.Sprintf(format, args...),

--- a/pointer/pointer_test.go
+++ b/pointer/pointer_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestAllPtrFieldsNil(t *testing.T) {
 	testCases := []struct {
-		obj      interface{}
+		obj      any
 		expected bool
 	}{
 		{struct{}{}, true},

--- a/ptr/ptr.go
+++ b/ptr/ptr.go
@@ -27,7 +27,7 @@ import (
 //
 // This function is only valid for structs and pointers to structs.  Any other
 // type will cause a panic.  Passing a typed nil pointer will return true.
-func AllPtrFieldsNil(obj interface{}) bool {
+func AllPtrFieldsNil(obj any) bool {
 	v := reflect.ValueOf(obj)
 	if !v.IsValid() {
 		panic(fmt.Sprintf("reflect.ValueOf() produced a non-valid Value for %#v", obj))

--- a/ptr/ptr_test.go
+++ b/ptr/ptr_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestAllPtrFieldsNil(t *testing.T) {
 	testCases := []struct {
-		obj      interface{}
+		obj      any
 		expected bool
 	}{
 		{struct{}{}, true},

--- a/semantic/deep_equal.go
+++ b/semantic/deep_equal.go
@@ -25,6 +25,6 @@ import (
 type Equalities = reflect.Equalities
 
 // EqualitiesOrDie adds the given funcs and panics on any error.
-func EqualitiesOrDie(funcs ...interface{}) Equalities {
+func EqualitiesOrDie(funcs ...any) Equalities {
 	return reflect.EqualitiesOrDie(funcs...)
 }

--- a/set/set.go
+++ b/set/set.go
@@ -34,7 +34,7 @@ func New[E ordered](items ...E) Set[E] {
 	return ss
 }
 
-// KeySet creates a Set[E] from a keys of a map[E](? extends interface{}).
+// KeySet creates a Set[E] from a keys of a map[E](? extends any).
 func KeySet[E ordered, A any](theMap map[E]A) Set[E] {
 	ret := Set[E]{}
 	for key := range theMap {

--- a/third_party/forked/golang/reflect/deep_equal.go
+++ b/third_party/forked/golang/reflect/deep_equal.go
@@ -17,7 +17,7 @@ import (
 type Equalities map[reflect.Type]reflect.Value
 
 // EqualitiesOrDie adds the given funcs and panics on any error.
-func EqualitiesOrDie(funcs ...interface{}) Equalities {
+func EqualitiesOrDie(funcs ...any) Equalities {
 	e := Equalities{}
 	if err := e.AddFuncs(funcs...); err != nil {
 		panic(err)
@@ -26,7 +26,7 @@ func EqualitiesOrDie(funcs ...interface{}) Equalities {
 }
 
 // AddFuncs is a shortcut for multiple calls to AddFunc.
-func (e Equalities) AddFuncs(funcs ...interface{}) error {
+func (e Equalities) AddFuncs(funcs ...any) error {
 	for _, f := range funcs {
 		if err := e.AddFunc(f); err != nil {
 			return err
@@ -37,7 +37,7 @@ func (e Equalities) AddFuncs(funcs ...interface{}) error {
 
 // AddFunc uses func as an equality function: it must take
 // two parameters of the same type, and return a boolean.
-func (e Equalities) AddFunc(eqFunc interface{}) error {
+func (e Equalities) AddFunc(eqFunc any) error {
 	fv := reflect.ValueOf(eqFunc)
 	ft := fv.Type()
 	if ft.Kind() != reflect.Func {
@@ -236,7 +236,7 @@ func (e Equalities) deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool,
 //
 // Unexported field members cannot be compared and will cause an informative panic; you must add an Equality
 // function for these types.
-func (e Equalities) DeepEqual(a1, a2 interface{}) bool {
+func (e Equalities) DeepEqual(a1, a2 any) bool {
 	if a1 == nil || a2 == nil {
 		return a1 == a2
 	}
@@ -385,7 +385,7 @@ func (e Equalities) deepValueDerive(v1, v2 reflect.Value, visited map[visit]bool
 // the semantic comparison.
 //
 // The unset fields include a nil pointer and an empty string.
-func (e Equalities) DeepDerivative(a1, a2 interface{}) bool {
+func (e Equalities) DeepDerivative(a1, a2 any) bool {
 	if a1 == nil {
 		return true
 	}

--- a/third_party/forked/golang/reflect/deep_equal_test.go
+++ b/third_party/forked/golang/reflect/deep_equal_test.go
@@ -33,7 +33,7 @@ func TestEqualities(t *testing.T) {
 	}
 
 	table := []struct {
-		a, b  interface{}
+		a, b  any
 		equal bool
 	}{
 		{1, 2, true},
@@ -97,7 +97,7 @@ func TestDerivates(t *testing.T) {
 	}
 
 	table := []struct {
-		a, b  interface{}
+		a, b  any
 		equal bool
 	}{
 		{1, 2, true},

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -34,7 +34,7 @@ var klogV = func(lvl klog.Level) bool {
 // Field is a key value pair that provides additional details about the trace.
 type Field struct {
 	Key   string
-	Value interface{}
+	Value any
 }
 
 func (f Field) format() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Replaces all instances of `interface{}` with `any` for improved readability and modern Go style.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
No functional changes; this is a style cleanup to use `any` instead of `interface{}` in Go 1.18+.


**Release note**:
```
NONE
```
