### PR TITLE
fake clock: expose the number of waiters

### DIFF
--- a/clock/testing/fake_clock.go
+++ b/clock/testing/fake_clock.go
@@ -221,12 +221,24 @@ func (f *FakeClock) setTimeLocked(t time.Time) {
 	f.waiters = newWaiters
 }
 
-// HasWaiters returns true if After or AfterFunc has been called on f but not yet satisfied (so you can
-// write race-free tests).
+// HasWaiters returns true if Waiters() returns non-0 (so you can write race-free tests).
 func (f *FakeClock) HasWaiters() bool {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	return len(f.waiters) > 0
+}
+
+// Waiters returns the number of "waiters" on the clock (so you can write race-free
+// tests). A waiter exists for:
+//   - every call to After that has not yet signaled its channel.
+//   - every call to AfterFunc that has not yet called its callback.
+//   - every timer created with NewTimer which is currently ticking.
+//   - every ticker created with NewTicker which is currently ticking.
+//   - every ticker created with Tick.
+func (f *FakeClock) Waiters() int {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return len(f.waiters)
 }
 
 // Sleep is akin to time.Sleep


### PR DESCRIPTION
By using `Waiters()`, tests can wait until the expected number of waiters are present before manipulating the clock's time, ensuring that the goroutine under test has reached a stable state regarding its timers.

 /kind feature
 /kind flake

**What this PR does / why we need it**:

When working on https://github.com/kubernetes/kubernetes/pull/131502 it took me a while to find the source of flakiness, the code under test uses two timers and runs in a goroutinge.

There is a race between the test code when updating the fake clock time, that may happen before the timers are reset.

The fake clock already has the `HasWaiters()` method, but that only works for one timer, leaving a small window for the race to happen. In order to avoid that, we need to expose the actual number of waiters to be able to synchronize the test .

**Release note**:
```
NONE
```

/assign @thockin @danwinship 