### PR TITLE
slices: delegate to Go slices

### DIFF
--- a/strings/slices/slices.go
+++ b/strings/slices/slices.go
@@ -20,20 +20,14 @@ limitations under the License.
 // replace "stringslices" if the "slices" package becomes standard.
 package slices
 
+import goslices "slices"
+
 // Equal reports whether two slices are equal: the same length and all
 // elements equal. If the lengths are different, Equal returns false.
 // Otherwise, the elements are compared in index order, and the
 // comparison stops at the first unequal pair.
 func Equal(s1, s2 []string) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	for i, n := range s1 {
-		if n != s2[i] {
-			return false
-		}
-	}
-	return true
+	return goslices.Equal(s1, s2)
 }
 
 // Filter appends to d each element e of s for which keep(e) returns true.
@@ -52,31 +46,16 @@ func Filter(d, s []string, keep func(string) bool) []string {
 
 // Contains reports whether v is present in s.
 func Contains(s []string, v string) bool {
-	return Index(s, v) >= 0
+	return goslices.Contains(s, v)
 }
 
 // Index returns the index of the first occurrence of v in s, or -1 if
 // not present.
 func Index(s []string, v string) int {
-	// "Contains" may be replaced with "Index(s, v) >= 0":
-	// https://github.com/golang/go/issues/45955#issuecomment-873377947
-	for i, n := range s {
-		if n == v {
-			return i
-		}
-	}
-	return -1
+	return goslices.Index(s, v)
 }
-
-// Functions below are not in https://github.com/golang/go/issues/45955
 
 // Clone returns a new clone of s.
 func Clone(s []string) []string {
-	// https://github.com/go101/go101/wiki/There-is-not-a-perfect-way-to-clone-slices-in-Go
-	if s == nil {
-		return nil
-	}
-	c := make([]string, len(s))
-	copy(c, s)
-	return c
+	return goslices.Clone(s)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This replaces `strings/slices` functions that have equivalents in Go’s `slices` package with calls to the latter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
