### PR TITLE
Bump to Go 1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.23.x, 1.25.x]
         platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -24,7 +24,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.23.x, 1.25.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -40,7 +40,7 @@ jobs:
   verify-go-directive:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.23.x, 1.25.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -72,7 +72,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.x
+          go-version: 1.23.x
       - name: Add GOBIN to PATH
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ vet:
 update-fmt:
 	gofmt -s -w .
 
-# We set the maximum version of the go directive as 1.20 here
+# We set the maximum version of the go directive as 1.23 here
 # because the oldest go directive that exists on our supported
-# release branches in k/k is 1.20.
+# release branches in k/k is 1.23.
 .PHONY: verify-go-directive
 verify-go-directive:
-	./hack/verify-go-directive.sh -g 1.20
+	./hack/verify-go-directive.sh -g 1.23

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/utils
 
-go 1.18
+go 1.23
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This bumps to the newest version of Go used by the oldest still supported branch of k/k (1.32, which uses Go 1.23).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This might run into issues with golangci-lint which should be bumped too. It would be best to use the corresponding GHA instead of the separate container image.

**Release note**:
```
NONE
```
