### PR TITLE
clock: don't recommend NewTimer

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -31,8 +31,8 @@ type PassiveClock interface {
 type Clock interface {
 	PassiveClock
 	// After returns the channel of a new Timer.
-	// This method does not allow to free/GC the backing timer before it fires. Use
-	// NewTimer instead.
+	// As of Go 1.23, the garbage collector can recover unreferenced,
+	// unstopped timers. There is no reason to prefer NewTimer when After will do.
 	After(d time.Duration) <-chan time.Time
 	// NewTimer returns a new Timer.
 	NewTimer(d time.Duration) Timer
@@ -40,8 +40,8 @@ type Clock interface {
 	// Consider making the sleep interruptible by using 'select' on a context channel and a timer channel.
 	Sleep(d time.Duration)
 	// Tick returns the channel of a new Ticker.
-	// This method does not allow to free/GC the backing ticker. Use
-	// NewTicker from WithTicker instead.
+	// As of Go 1.23, the garbage collector can recover unreferenced
+	// tickers, even if they haven't been stopped.
 	Tick(d time.Duration) <-chan time.Time
 }
 
@@ -95,8 +95,8 @@ func (RealClock) Since(ts time.Time) time.Duration {
 }
 
 // After is the same as time.After(d).
-// This method does not allow to free/GC the backing timer before it fires. Use
-// NewTimer instead.
+// As of Go 1.23, the garbage collector can recover unreferenced,
+// unstopped timers. There is no reason to prefer NewTimer when After will do.
 func (RealClock) After(d time.Duration) <-chan time.Time {
 	return time.After(d)
 }
@@ -116,8 +116,8 @@ func (RealClock) AfterFunc(d time.Duration, f func()) Timer {
 }
 
 // Tick is the same as time.Tick(d)
-// This method does not allow to free/GC the backing ticker. Use
-// NewTicker instead.
+// As of Go 1.23, the garbage collector can recover unreferenced
+// tickers, even if they haven't been stopped.
 func (RealClock) Tick(d time.Duration) <-chan time.Time {
 	return time.Tick(d)
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

The GC issue is already resolved in Go 1.23. Copying the comments from time.After() to explain this.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
