### PR TITLE
Provide a Go 1.26 new() version of ptr.To()

### DIFF
--- a/ptr/ptr.go
+++ b/ptr/ptr.go
@@ -46,11 +46,6 @@ func AllPtrFieldsNil(obj interface{}) bool {
 	return true
 }
 
-// To returns a pointer to the given value.
-func To[T any](v T) *T {
-	return &v
-}
-
 // Deref dereferences ptr and returns the value it points to if not nil, or else
 // returns def.
 func Deref[T any](ptr *T, def T) T {

--- a/ptr/ptr_go125.go
+++ b/ptr/ptr_go125.go
@@ -1,0 +1,24 @@
+//go:build !go1.26
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ptr
+
+// To returns a pointer to the given value.
+func To[T any](v T) *T {
+	return &v
+}

--- a/ptr/ptr_go126.go
+++ b/ptr/ptr_go126.go
@@ -1,0 +1,27 @@
+//go:build go1.26
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ptr
+
+// To returns a pointer to the given value.
+// Deprecated: Use new(T) instead.
+//
+//go:fix inline
+func To[T any](v T) *T {
+	return new(v)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This provides a Go 1.26-specific version of `ptr.To()` delegating to `new()`. The main purpose of this is to allow Go 1.26 codebases relying on `ptr.To()` to automatically migrate to `new()` using `go fix`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
